### PR TITLE
Output the generated AST helpers in a module so they can be reused.

### DIFF
--- a/lib/kpeg/code_generator.rb
+++ b/lib/kpeg/code_generator.rb
@@ -83,14 +83,14 @@ module KPeg
 
       if output_node
         code << "  end\n"
-        code << "  module #{root}Helpers\n"
+        code << "  module #{root}Construction\n"
         methods.each do |short, name, attrs|
           code << "    def #{short}(#{attrs.join(', ')})\n"
           code << "      #{root}::#{name}.new(#{attrs.join(', ')})\n"
           code << "    end\n"
         end
         code << "  end\n"
-        code << "  include #{root}Helpers\n"
+        code << "  include #{root}Construction\n"
       end
     end
 

--- a/test/test_kpeg_code_generator.rb
+++ b/test/test_kpeg_code_generator.rb
@@ -1661,7 +1661,7 @@ class Test < KPeg::CompiledParser
       end
     end
   end
-  module ASTHelpers
+  module ASTConstruction
     def bracket(receiver, argument)
       AST::BracketOperator.new(receiver, argument)
     end
@@ -1672,7 +1672,7 @@ class Test < KPeg::CompiledParser
       AST::Simple2.new()
     end
   end
-  include ASTHelpers
+  include ASTConstruction
 
   # root = .
   def _root
@@ -1718,12 +1718,12 @@ class Test < KPeg::CompiledParser
       attr_reader :argument
     end
   end
-  module MegaASTHelpers
+  module MegaASTConstruction
     def bracket(receiver, argument)
       MegaAST::BracketOperator.new(receiver, argument)
     end
   end
-  include MegaASTHelpers
+  include MegaASTConstruction
 
   # root = .
   def _root


### PR DESCRIPTION
I wanted to use the generated AST helper methods to simplify some tests. Putting them inside a module which the generated parser class extends allows other classes to use the helpers, too.
