### PR TITLE
Fix bin/kpeg when there are no arguments passed in

### DIFF
--- a/bin/kpeg
+++ b/bin/kpeg
@@ -8,7 +8,7 @@ require 'kpeg/grammar_renderer'
 require 'optparse'
 
 options = {}
-OptionParser.new do |o|
+optparser = OptionParser.new do |o|
   o.banner = "Usage: kpeg [options]"
 
   o.on("-t", "--test", "Syntax check the file only") do |v|
@@ -42,7 +42,14 @@ OptionParser.new do |o|
   o.on("-d", "--debug", "Debug parsing the file") do |v|
     options[:debug] = v
   end
-end.parse!
+end
+
+optparser.parse!
+
+if ARGV.empty?
+  puts optparser.help
+  exit 1
+end
 
 file = ARGV.shift
 


### PR DESCRIPTION
Was just playing around with a simple parser and noticed the following happens when you don't pass any arguments to kpeg:

```
sjothen@air% kpeg                                                    
/Library/Ruby/Gems/1.8/gems/kpeg-0.10.0/bin/kpeg:49:in `exists?': can't convert nil into String (TypeError)
	from /Library/Ruby/Gems/1.8/gems/kpeg-0.10.0/bin/kpeg:49
	from /usr/bin/kpeg:19:in `load'
	from /usr/bin/kpeg:19
```

This PR just adds a check after option parsing to print out the help information if no arguments are passed in.