### PR TITLE
merge v1.0.0 into master

### DIFF
--- a/kpeg.gemspec
+++ b/kpeg.gemspec
@@ -1,42 +1,42 @@
 # -*- encoding: utf-8 -*-
+# stub: kpeg 1.0.0.20140103162640 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "kpeg"
-  s.version = "0.8.5.20120306163408"
+  s.version = "1.0.0.20140103162640"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.authors = ["Eric Hodel"]
-  s.cert_chain = ["/Users/drbrain/.gem/gem-public_cert.pem"]
-  s.date = "2012-03-07"
+  s.authors = ["Evan Phoenix"]
+  s.date = "2014-01-04"
   s.description = "KPeg is a simple PEG library for Ruby. It provides an API as well as native\ngrammar to build the grammar.\n\nKPeg strives to provide a simple, powerful API without being too exotic.\n\nKPeg supports direct left recursion of rules via the\n{OMeta memoization}[http://www.vpri.org/pdf/tr2008003_experimenting.pdf] trick."
-  s.email = ["drbrain@segment7.net"]
+  s.email = ["evan@fallingsnow.net"]
   s.executables = ["kpeg"]
-  s.extra_rdoc_files = ["History.txt", "Manifest.txt", "README.rdoc"]
-  s.files = [".autotest", "Gemfile", "Gemfile.lock", "History.txt", "LICENSE", "Manifest.txt", "README.rdoc", "Rakefile", "bin/kpeg", "examples/calculator/calculator.kpeg", "examples/calculator/calculator.rb", "examples/foreign_reference/literals.kpeg", "examples/foreign_reference/matcher.kpeg", "examples/foreign_reference/matcher.rb", "examples/lua_string/driver.rb", "examples/lua_string/lua_string.kpeg", "examples/lua_string/lua_string.kpeg.rb", "examples/phone_number/README.md", "examples/phone_number/phone_number.kpeg", "examples/phone_number/phone_number.rb", "examples/upper/README.md", "examples/upper/upper.kpeg", "examples/upper/upper.rb", "kpeg.gemspec", "lib/kpeg.rb", "lib/kpeg/code_generator.rb", "lib/kpeg/compiled_parser.rb", "lib/kpeg/format.kpeg", "lib/kpeg/format_parser.rb", "lib/kpeg/grammar.rb", "lib/kpeg/grammar_renderer.rb", "lib/kpeg/match.rb", "lib/kpeg/parser.rb", "lib/kpeg/position.rb", "lib/kpeg/string_escape.kpeg", "lib/kpeg/string_escape.rb", "lib/kpeg/version.rb", "test/inputs/comments.kpeg", "test/test_file_parser_roundtrip.rb", "test/test_gen_calc.rb", "test/test_kpeg.rb", "test/test_kpeg_code_generator.rb", "test/test_kpeg_compiled_parser.rb", "test/test_kpeg_format.rb", "test/test_kpeg_grammar_renderer.rb", "test/test_left_recursion.rb", "vim/syntax_kpeg/ftdetect/kpeg.vim", "vim/syntax_kpeg/syntax/kpeg.vim", ".gemtest"]
+  s.extra_rdoc_files = ["History.txt", "Manifest.txt", "README.rdoc", "examples/phone_number/README.md", "examples/upper/README.md"]
+  s.files = [".autotest", ".travis.yml", "History.txt", "LICENSE", "Manifest.txt", "README.rdoc", "Rakefile", "bin/kpeg", "examples/calculator/calculator.kpeg", "examples/calculator/calculator.rb", "examples/foreign_reference/literals.kpeg", "examples/foreign_reference/matcher.kpeg", "examples/foreign_reference/matcher.rb", "examples/lua_string/driver.rb", "examples/lua_string/lua_string.kpeg", "examples/lua_string/lua_string.kpeg.rb", "examples/phone_number/README.md", "examples/phone_number/phone_number.kpeg", "examples/phone_number/phone_number.rb", "examples/upper/README.md", "examples/upper/upper.kpeg", "examples/upper/upper.rb", "kpeg.gemspec", "lib/hoe/kpeg.rb", "lib/kpeg.rb", "lib/kpeg/code_generator.rb", "lib/kpeg/compiled_parser.rb", "lib/kpeg/format_parser.kpeg", "lib/kpeg/format_parser.rb", "lib/kpeg/grammar.rb", "lib/kpeg/grammar_renderer.rb", "lib/kpeg/match.rb", "lib/kpeg/parser.rb", "lib/kpeg/position.rb", "lib/kpeg/string_escape.kpeg", "lib/kpeg/string_escape.rb", "test/inputs/comments.kpeg", "test/test_kpeg.rb", "test/test_kpeg_code_generator.rb", "test/test_kpeg_compiled_parser.rb", "test/test_kpeg_format.rb", "test/test_kpeg_format_parser_round_trip.rb", "test/test_kpeg_grammar.rb", "test/test_kpeg_grammar_renderer.rb", "vim/syntax_kpeg/ftdetect/kpeg.vim", "vim/syntax_kpeg/syntax/kpeg.vim", "test/test_kpeg_string_escape.rb", ".gemtest"]
   s.homepage = "https://github.com/evanphx/kpeg"
+  s.licenses = ["MIT"]
   s.rdoc_options = ["--main", "README.rdoc"]
   s.require_paths = ["lib"]
   s.rubyforge_project = "kpeg"
-  s.rubygems_version = "1.8.12"
-  s.signing_key = "/Users/drbrain/.gem/gem-private_key.pem"
+  s.rubygems_version = "2.1.10"
   s.summary = "KPeg is a simple PEG library for Ruby"
-  s.test_files = ["test/test_file_parser_roundtrip.rb", "test/test_gen_calc.rb", "test/test_kpeg.rb", "test/test_kpeg_code_generator.rb", "test/test_kpeg_compiled_parser.rb", "test/test_kpeg_format.rb", "test/test_kpeg_grammar_renderer.rb", "test/test_left_recursion.rb"]
+  s.test_files = ["test/test_kpeg.rb", "test/test_kpeg_code_generator.rb", "test/test_kpeg_compiled_parser.rb", "test/test_kpeg_format.rb", "test/test_kpeg_format_parser_round_trip.rb", "test/test_kpeg_grammar.rb", "test/test_kpeg_grammar_renderer.rb", "test/test_kpeg_string_escape.rb"]
 
   if s.respond_to? :specification_version then
-    s.specification_version = 3
+    s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_development_dependency(%q<minitest>, ["~> 2.11"])
-      s.add_development_dependency(%q<rdoc>, ["~> 3.10"])
-      s.add_development_dependency(%q<hoe>, ["~> 2.15"])
+      s.add_development_dependency(%q<minitest>, ["~> 5.2"])
+      s.add_development_dependency(%q<rdoc>, ["~> 4.0"])
+      s.add_development_dependency(%q<hoe>, ["~> 3.7"])
     else
-      s.add_dependency(%q<minitest>, ["~> 2.11"])
-      s.add_dependency(%q<rdoc>, ["~> 3.10"])
-      s.add_dependency(%q<hoe>, ["~> 2.15"])
+      s.add_dependency(%q<minitest>, ["~> 5.2"])
+      s.add_dependency(%q<rdoc>, ["~> 4.0"])
+      s.add_dependency(%q<hoe>, ["~> 3.7"])
     end
   else
-    s.add_dependency(%q<minitest>, ["~> 2.11"])
-    s.add_dependency(%q<rdoc>, ["~> 3.10"])
-    s.add_dependency(%q<hoe>, ["~> 2.15"])
+    s.add_dependency(%q<minitest>, ["~> 5.2"])
+    s.add_dependency(%q<rdoc>, ["~> 4.0"])
+    s.add_dependency(%q<hoe>, ["~> 3.7"])
   end
 end

--- a/lib/kpeg.rb
+++ b/lib/kpeg.rb
@@ -1,6 +1,6 @@
 module KPeg
 
-  VERSION = "0.10.0"
+  VERSION = "1.0.0"
 
   def self.grammar
     g = Grammar.new


### PR DESCRIPTION
cf. #30 

Without this commit, `rake test` failed.

```
mba:kpeg maki$ bundle i
Resolving dependencies...
Using rake 0.9.6 (was 10.4.2)
Using hoe 2.16.1 (was 3.14.2)
Using json 1.8.3
Using kpeg 0.8.5.20120306163408 (was 1.0.0.20140103162640) from source at .
Using minitest 2.12.1 (was 5.8.3)
Using rdoc 3.12.2 (was 4.2.0)
Using bundler 1.10.6
Bundle complete! 4 Gemfile dependencies, 7 gems now installed.
Use `bundle show [gemname]` to see where a bundled gem is installed.
mba:kpeg maki$ bundle exec rake test
/Users/maki/.rbenv/versions/2.2.2/bin/ruby -w -Ilib:bin:test:. -e 'require "rubygems"; gem "minitest"; require "minitest/autorun"; require "test/test_kpeg.rb"; require "test/test_kpeg_code_generator.rb"; require "test/test_kpeg_compiled_parser.rb"; require "test/test_kpeg_format.rb"; require "test/test_kpeg_format_parser_round_trip.rb"; require "test/test_kpeg_grammar.rb"; require "test/test_kpeg_grammar_renderer.rb"; require "test/test_kpeg_string_escape.rb"' -- 
/Users/maki/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/minitest-2.12.1/lib/minitest/unit.rb:19:in `const_missing': uninitialized constant MiniTest::Test (NameError)
	from /Users/maki/tmp/kpeg/test/test_kpeg.rb:5:in `<top (required)>'
	from -e:1:in `require'
	from -e:1:in `<main>'
rake aborted!
Command failed with status (1): [/Users/maki/.rbenv/versions/2.2.2/bin/ruby...]

Tasks: TOP => test
(See full trace by running task with --trace)
mba:kpeg maki$ 
```

With this commit, succeed.

```
mba:kpeg maki$ bundle i
Resolving dependencies...
Using rake 10.4.2 (was 0.9.6)
Using hoe 3.14.2 (was 2.16.1)
Using kpeg 1.0.0.20140103162640 (was 0.8.5.20120306163408) from source at .
Using minitest 5.8.3 (was 2.12.1)
Using rdoc 4.2.0 (was 3.12.2)
Using bundler 1.10.6
Bundle complete! 4 Gemfile dependencies, 6 gems now installed.
Use `bundle show [gemname]` to see where a bundled gem is installed.
mba:kpeg maki$ bundle exec rake test
Defaulting gemspec to MIT license.
Call license in hoe spec to change.
/Users/maki/.rbenv/versions/2.2.2/bin/ruby -w -Ilib:bin:test:. -e 'require "rubygems"; gem "minitest"; require "minitest/autorun"; require "test/test_kpeg.rb"; require "test/test_kpeg_code_generator.rb"; require "test/test_kpeg_compiled_parser.rb"; require "test/test_kpeg_format.rb"; require "test/test_kpeg_format_parser_round_trip.rb"; require "test/test_kpeg_grammar.rb"; require "test/test_kpeg_grammar_renderer.rb"; require "test/test_kpeg_string_escape.rb"' -- 
Run options: --seed 37576

# Running:

..............................................................................................................................................................................

Finished in 1.010620s, 172.1715 runs/s, 464.0714 assertions/s.

174 runs, 469 assertions, 0 failures, 0 errors, 0 skips
```