### PR TITLE
Fix current_column return value when position is 0

### DIFF
--- a/lib/kpeg/format_parser.rb
+++ b/lib/kpeg/format_parser.rb
@@ -19,7 +19,7 @@ class KPeg::FormatParser
     attr_accessor :result, :pos
 
     def current_column(target=pos)
-      if c = string.rindex("\n", target-1)
+      if target > 0 && c = string.rindex("\n", target-1)
         return target - c - 1
       end
 

--- a/lib/kpeg/position.rb
+++ b/lib/kpeg/position.rb
@@ -3,7 +3,7 @@ module KPeg
     # STANDALONE START
 
     def current_column(target=pos)
-      if c = string.rindex("\n", target-1)
+      if target > 0 && c = string.rindex("\n", target-1)
         return target - c - 1
       end
 

--- a/lib/kpeg/string_escape.rb
+++ b/lib/kpeg/string_escape.rb
@@ -27,7 +27,7 @@ class KPeg::StringEscape
     attr_accessor :result, :pos
 
     def current_column(target=pos)
-      if c = string.rindex("\n", target-1)
+      if target > 0 && c = string.rindex("\n", target-1)
         return target - c - 1
       end
 

--- a/test/test_kpeg_compiled_parser.rb
+++ b/test/test_kpeg_compiled_parser.rb
@@ -21,6 +21,7 @@ class TestKPegCompiledParser < Minitest::Test
 
   def test_current_column
     r = TestParser.new "hello\nsir"
+    assert_equal 1, r.current_column(0)
     assert_equal 2, r.current_column(1)
     assert_equal 6, r.current_column(5)
     assert_equal 1, r.current_column(7)


### PR DESCRIPTION
When pos = 0, the call to rindex would search with a negative value, resulting in the current column value returning a negative number.

The first thing I added was a test, which confirmed my suspicion that there was a bug (and not something wrong in my grammar)

```
  1) Failure:
TestKPegCompiledParser#test_current_column [/Users/keithpitt/Development/kpeg/test/test_kpeg_compiled_parser.rb:24]:
Expected: 1
  Actual: -6
```

I think the proposed fix should be fine? Let me know if there's any other changes I should make!