### PR TITLE
Speed up Postion#current_line

### DIFF
--- a/lib/kpeg/format_parser.rb
+++ b/lib/kpeg/format_parser.rb
@@ -27,16 +27,17 @@ class KPeg::FormatParser
     end
 
     def current_line(target=pos)
-      cur_offset = 0
-      cur_line = 0
-
-      string.each_line do |line|
-        cur_line += 1
-        cur_offset += line.size
-        return cur_line if cur_offset >= target
+      unless @line_offsets
+        @line_offsets = [-1]
+        total = 0
+        string.each_line do |line|
+          @line_offsets << total
+          total += line.size
+        end
+        @line_offsets << total
       end
 
-      -1
+      @line_offsets.bsearch_index {|x| x >= target } || -1
     end
 
     def lines

--- a/lib/kpeg/position.rb
+++ b/lib/kpeg/position.rb
@@ -11,16 +11,17 @@ module KPeg
     end
 
     def current_line(target=pos)
-      cur_offset = 0
-      cur_line = 0
-
-      string.each_line do |line|
-        cur_line += 1
-        cur_offset += line.size
-        return cur_line if cur_offset >= target
+      unless @line_offsets
+        @line_offsets = [-1]
+        total = 0
+        string.each_line do |line|
+          @line_offsets << total
+          total += line.size
+        end
+        @line_offsets << total
       end
 
-      -1
+      @line_offsets.bsearch_index {|x| x >= target } || -1
     end
 
     def lines

--- a/lib/kpeg/string_escape.rb
+++ b/lib/kpeg/string_escape.rb
@@ -35,16 +35,17 @@ class KPeg::StringEscape
     end
 
     def current_line(target=pos)
-      cur_offset = 0
-      cur_line = 0
-
-      string.each_line do |line|
-        cur_line += 1
-        cur_offset += line.size
-        return cur_line if cur_offset >= target
+      unless @line_offsets
+        @line_offsets = [-1]
+        total = 0
+        string.each_line do |line|
+          @line_offsets << total
+          total += line.size
+        end
+        @line_offsets << total
       end
 
-      -1
+      @line_offsets.bsearch_index {|x| x >= target } || -1
     end
 
     def lines


### PR DESCRIPTION
This optimization will lazily build a list of beginning line offsets which
are then searched via Array#bsearch_index.  I did not exhaustively test
this but in looping on tiny_markdown and calling it 1000 times the before
time (MRI 2.7) was ~2.8s and after went down to ~2.3s.  This is remarkable
if you consider the sample file is only 52 lines long!  If I extend the size
of sample.md to be 1990 lines long the time goes from 12m38s to 1m59s!!!

driver.rb changes (examples/tiny_markdown): 

```ruby
module TinyMarkdown; end
require_relative 'tiny_markdown.kpeg.rb'
require_relative 'node.rb'

md = File.read(ARGV[0])

1_000.times do
  parser = TinyMarkdown::Parser.new(md)
  parser.parse
  ast = parser.ast
end
#puts ast.to_html

```