### PR TITLE
Fix line calculation issues.

### DIFF
--- a/lib/kpeg/format_parser.rb
+++ b/lib/kpeg/format_parser.rb
@@ -30,7 +30,7 @@ class KPeg::FormatParser
     if [].respond_to? :bsearch_index
       def current_line(target=pos)
         unless @line_offsets
-          @line_offsets = [-1]
+          @line_offsets = []
           total = 0
           string.each_line do |line|
             @line_offsets << total
@@ -39,7 +39,7 @@ class KPeg::FormatParser
           @line_offsets << total
         end
 
-        @line_offsets.bsearch_index {|x| x >= target } || -1
+        @line_offsets.bsearch_index {|x| x >= target } + 1 || -1
       end
     else
       def current_line(target=pos)

--- a/lib/kpeg/position.rb
+++ b/lib/kpeg/position.rb
@@ -13,7 +13,7 @@ module KPeg
     if [].respond_to? :bsearch_index
       def current_line(target=pos)
         unless @line_offsets
-          @line_offsets = [-1]
+          @line_offsets = []
           total = 0
           string.each_line do |line|
             @line_offsets << total
@@ -22,7 +22,7 @@ module KPeg
           @line_offsets << total
         end
 
-        @line_offsets.bsearch_index {|x| x >= target } || -1
+        @line_offsets.bsearch_index {|x| x >= target } + 1 || -1
       end
     else
       def current_line(target=pos)

--- a/lib/kpeg/string_escape.rb
+++ b/lib/kpeg/string_escape.rb
@@ -38,7 +38,7 @@ class KPeg::StringEscape
     if [].respond_to? :bsearch_index
       def current_line(target=pos)
         unless @line_offsets
-          @line_offsets = [-1]
+          @line_offsets = []
           total = 0
           string.each_line do |line|
             @line_offsets << total
@@ -47,7 +47,7 @@ class KPeg::StringEscape
           @line_offsets << total
         end
 
-        @line_offsets.bsearch_index {|x| x >= target } || -1
+        @line_offsets.bsearch_index {|x| x >= target } + 1 || -1
       end
     else
       def current_line(target=pos)


### PR DESCRIPTION
This should fix #45.

The idea of adding a bogus -1 entry to line offsets ended up
causing the bisect to somehow return a value which is longer
than the actual number of lines of the source.

The fix is to remove that and just add the 1 index via addition.

Current problem is I have been unable to write up a simplified
test case showing the original problem so I have no test.