### PR TITLE
Fix line calculation issues in kpeg 1.2.0

### DIFF
--- a/lib/kpeg/format_parser.rb
+++ b/lib/kpeg/format_parser.rb
@@ -33,10 +33,9 @@ class KPeg::FormatParser
           @line_offsets = []
           total = 0
           string.each_line do |line|
-            @line_offsets << total
             total += line.size
+            @line_offsets << total
           end
-          @line_offsets << total
         end
 
         @line_offsets.bsearch_index {|x| x >= target } + 1 || -1

--- a/lib/kpeg/format_parser.rb
+++ b/lib/kpeg/format_parser.rb
@@ -30,7 +30,7 @@ class KPeg::FormatParser
     if [].respond_to? :bsearch_index
       def current_line(target=pos)
         unless @line_offsets
-          @line_offsets = [-1]
+          @line_offsets = []
           total = 0
           string.each_line do |line|
             @line_offsets << total
@@ -39,7 +39,7 @@ class KPeg::FormatParser
           @line_offsets << total
         end
 
-        @line_offsets.bsearch_index {|x| x >= target } || -1
+        @line_offsets.bsearch_index {|x| x >= target } + 1 || -1
       end
     else
       def current_line(target=pos)

--- a/lib/kpeg/position.rb
+++ b/lib/kpeg/position.rb
@@ -16,10 +16,9 @@ module KPeg
           @line_offsets = []
           total = 0
           string.each_line do |line|
-            @line_offsets << total
             total += line.size
+            @line_offsets << total
           end
-          @line_offsets << total
         end
 
         @line_offsets.bsearch_index {|x| x >= target } + 1 || -1

--- a/lib/kpeg/position.rb
+++ b/lib/kpeg/position.rb
@@ -13,7 +13,7 @@ module KPeg
     if [].respond_to? :bsearch_index
       def current_line(target=pos)
         unless @line_offsets
-          @line_offsets = [-1]
+          @line_offsets = []
           total = 0
           string.each_line do |line|
             @line_offsets << total
@@ -22,7 +22,7 @@ module KPeg
           @line_offsets << total
         end
 
-        @line_offsets.bsearch_index {|x| x >= target } || -1
+        @line_offsets.bsearch_index {|x| x >= target } + 1 || -1
       end
     else
       def current_line(target=pos)

--- a/lib/kpeg/string_escape.rb
+++ b/lib/kpeg/string_escape.rb
@@ -38,7 +38,7 @@ class KPeg::StringEscape
     if [].respond_to? :bsearch_index
       def current_line(target=pos)
         unless @line_offsets
-          @line_offsets = [-1]
+          @line_offsets = []
           total = 0
           string.each_line do |line|
             @line_offsets << total
@@ -47,7 +47,7 @@ class KPeg::StringEscape
           @line_offsets << total
         end
 
-        @line_offsets.bsearch_index {|x| x >= target } || -1
+        @line_offsets.bsearch_index {|x| x >= target } + 1 || -1
       end
     else
       def current_line(target=pos)

--- a/lib/kpeg/string_escape.rb
+++ b/lib/kpeg/string_escape.rb
@@ -41,10 +41,9 @@ class KPeg::StringEscape
           @line_offsets = []
           total = 0
           string.each_line do |line|
-            @line_offsets << total
             total += line.size
+            @line_offsets << total
           end
-          @line_offsets << total
         end
 
         @line_offsets.bsearch_index {|x| x >= target } + 1 || -1

--- a/test/test_kpeg_compiled_parser.rb
+++ b/test/test_kpeg_compiled_parser.rb
@@ -7,6 +7,7 @@ class TestKPegCompiledParser < Minitest::Test
 
   gram = <<-GRAM
   letter = [a-z]
+  number = [0-9]
   root = letter
   GRAM
 
@@ -14,7 +15,7 @@ class TestKPegCompiledParser < Minitest::Test
 
   gram = <<-GRAM
   %test = TestKPegCompiledParser::TestParser
-  root = %test.letter "!"
+  root = %test.letter %test.number? "!"
   GRAM
 
   KPeg.compile gram, "CompTestParser", self
@@ -75,6 +76,14 @@ class TestKPegCompiledParser < Minitest::Test
     assert !r.parse, "should parse"
 
     expected = "@1:1 failed rule 'TestKPegCompiledParser::TestParser#_letter', got '9'"
+    assert_equal expected, r.failure_oneline
+  end
+
+  def test_composite_two_char_error
+    r = CompTestParser.new "aa"
+    assert_nil r.parse, "should not parse"
+
+    expected = "@1:2 failed rule 'TestKPegCompiledParser::TestParser#_number', got 'a'"
     assert_equal expected, r.failure_oneline
   end
 


### PR DESCRIPTION
This replaces #46 (which had a partial fix) with an extra change and test to complete the fix.

The test passes on 1.1.0 and this branch, but fails with 1.2.0.

Fixes #45 