### PR TITLE
Add Ruby 3.1 to CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,15 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0']
+        ruby-version: ['2.6', '2.7', '3.0', '3.1']
 
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@473e4d8fe5dd94ee328fdfca9f8c9c7afc9dae5e
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/test/test_kpeg.rb
+++ b/test/test_kpeg.rb
@@ -22,7 +22,7 @@ class TestKPeg < Minitest::Test
     end
 
     assert_match KPeg.match("hello", gram), "hello"
-    assert_equal nil, KPeg.match("vador", gram)
+    assert_nil KPeg.match("vador", gram)
   end
 
   def test_reg
@@ -48,7 +48,7 @@ class TestKPeg < Minitest::Test
 
     assert_match KPeg.match("hello", gram), "hello"
     assert_match KPeg.match("chicken", gram), "chicken"
-    assert_equal nil, KPeg.match("vador", gram)
+    assert_nil KPeg.match("vador", gram)
   end
 
   def test_maybe
@@ -78,7 +78,7 @@ class TestKPeg < Minitest::Test
       assert_match sm, "run"
     end
 
-    assert_equal nil, KPeg.match("vador", gram)
+    assert_nil KPeg.match("vador", gram)
   end
 
   def test_kleene
@@ -124,9 +124,9 @@ class TestKPeg < Minitest::Test
       assert_match sm, "run"
     end
 
-    assert_equal nil, KPeg.match("run", gram) 
-    assert_equal nil, KPeg.match("runrunrunrunrun", gram) 
-    assert_equal nil, KPeg.match("vador", gram) 
+    assert_nil KPeg.match("run", gram) 
+    assert_nil KPeg.match("runrunrunrunrun", gram) 
+    assert_nil KPeg.match("vador", gram) 
   end
 
   def test_seq
@@ -141,8 +141,8 @@ class TestKPeg < Minitest::Test
 
     assert_equal m.value, ["hello", ", world"]
 
-    assert_equal nil, KPeg.match("vador", gram)
-    assert_equal nil, KPeg.match("hello, vador", gram)
+    assert_nil KPeg.match("vador", gram)
+    assert_nil KPeg.match("hello, vador", gram)
   end
 
   def test_andp
@@ -346,7 +346,7 @@ class TestKPeg < Minitest::Test
     parser = KPeg::Parser.new "hello", gram
     m = parser.parse
 
-    assert_equal nil, m
+    assert_nil m
   end
 
   def test_math_grammar

--- a/test/test_kpeg_code_generator.rb
+++ b/test/test_kpeg_code_generator.rb
@@ -1079,7 +1079,7 @@ end
 
     code = cg.make("")
     assert code.parse
-    assert_equal nil, code.result
+    assert_nil code.result
   end
 
 


### PR DESCRIPTION
This PR adds Ruby 3.1 to the CI matrix.  It also:

1. Switches to using version 1 of setup-ruby, since that's fairly standard at this point.
2. Fixes some trivial deprecation warnings in the tests