### PR TITLE
reset result on apply

### DIFF
--- a/lib/kpeg/compiled_parser.rb
+++ b/lib/kpeg/compiled_parser.rb
@@ -236,6 +236,7 @@ module KPeg
     end
 
     def apply_with_args(rule, *args)
+      @result = nil
       memo_key = [rule, args]
       if m = @memoizations[memo_key][@pos]
         @pos = m.pos
@@ -269,6 +270,7 @@ module KPeg
     end
 
     def apply(rule)
+      @result = nil
       if m = @memoizations[rule][@pos]
         @pos = m.pos
         if !m.set

--- a/lib/kpeg/format_parser.rb
+++ b/lib/kpeg/format_parser.rb
@@ -256,6 +256,7 @@ class KPeg::FormatParser
     end
 
     def apply_with_args(rule, *args)
+      @result = nil
       memo_key = [rule, args]
       if m = @memoizations[memo_key][@pos]
         @pos = m.pos
@@ -289,6 +290,7 @@ class KPeg::FormatParser
     end
 
     def apply(rule)
+      @result = nil
       if m = @memoizations[rule][@pos]
         @pos = m.pos
         if !m.set

--- a/lib/kpeg/string_escape.rb
+++ b/lib/kpeg/string_escape.rb
@@ -264,6 +264,7 @@ class KPeg::StringEscape
     end
 
     def apply_with_args(rule, *args)
+      @result = nil
       memo_key = [rule, args]
       if m = @memoizations[memo_key][@pos]
         @pos = m.pos
@@ -297,6 +298,7 @@ class KPeg::StringEscape
     end
 
     def apply(rule)
+      @result = nil
       if m = @memoizations[rule][@pos]
         @pos = m.pos
         if !m.set

--- a/test/test_kpeg_compiled_parser.rb
+++ b/test/test_kpeg_compiled_parser.rb
@@ -20,6 +20,15 @@ class TestKPegCompiledParser < Minitest::Test
 
   KPeg.compile gram, "CompTestParser", self
 
+  gram = <<-GRAM
+  letter = < [a-z] > { text }
+  number = [0-9]
+  n_or_l = letter | number
+  root = letter:l n_or_l*:n { [l, n] }
+  GRAM
+
+  KPeg.compile gram, "ProdTestParser", self
+
   def test_current_column
     r = TestParser.new "hello\nsir"
     assert_equal 2, r.current_column(1)
@@ -87,4 +96,52 @@ class TestKPegCompiledParser < Minitest::Test
     assert_equal expected, r.failure_oneline
   end
 
+  def test_producing_parser_one_product
+    r = ProdTestParser.new "a"
+    assert r.parse, "should parse"
+
+    assert_equal ["a", []], r.result
+  end
+
+  def test_producing_parser_two_products
+    r = ProdTestParser.new "ab"
+    assert r.parse, "should parse"
+
+    assert_equal ["a", ["b"]], r.result
+  end
+
+  def test_producing_parser_three_products
+    r = ProdTestParser.new "abc"
+    assert r.parse, "should parse"
+
+    assert_equal ["a", ["b", "c"]], r.result
+  end
+
+  def test_producing_parser_product_and_nil
+    r = ProdTestParser.new "a1"
+    assert r.parse, "should parse"
+
+    assert_equal ["a", [nil]], r.result
+  end
+
+  def test_producing_parser_product_and_nil2
+    r = ProdTestParser.new "a1b"
+    assert r.parse, "should parse"
+
+    assert_equal ["a", [nil, "b"]], r.result
+  end
+
+  def test_producing_parser_product_and_nil3
+    r = ProdTestParser.new "ab1"
+    assert r.parse, "should parse"
+
+    assert_equal ["a", ["b", nil]], r.result
+  end
+
+  def test_producing_parser_product_and_nil4
+    r = ProdTestParser.new "a12"
+    assert r.parse, "should parse"
+
+    assert_equal ["a", [nil, nil]], r.result
+  end
 end


### PR DESCRIPTION
It fixes duplicate production of previous rule application on non-producing entries:

    rule_a = rule_b:b rule_c*:c { [b, c] }
    rule_b = <"b"> { text }
    rule_c = "c"

In example rule_c doesn't produce result, so result of rule_b is copied.

It first were mentioned in #41 

After patch rule_c "produces" nil.

Fixes #41 