### PR TITLE
Removed 3rd argument of Regexp.new.

### DIFF
--- a/lib/kpeg/grammar.rb
+++ b/lib/kpeg/grammar.rb
@@ -106,20 +106,10 @@ module KPeg
 
       if reg.kind_of? String
         flags = 0
-        lang = nil
 
         if opts
           opts.split("").each do |o|
             case o
-            when "n", "N", "e", "E", "s", "S"
-              lang = o.downcase
-            when "u", "U"
-              if RUBY_VERSION > "1.8.7"
-                # Ruby 1.9 defaults to UTF-8 for string matching
-                lang = ""
-              else
-                lang = "u"
-              end
             when "m"
               flags |= Regexp::MULTILINE
             when "x"
@@ -130,7 +120,7 @@ module KPeg
           end
         end
 
-        @regexp = Regexp.new(reg, flags, lang)
+        @regexp = Regexp.new(reg, flags)
       else
         @regexp = reg
       end


### PR DESCRIPTION
This argument is broken and deprecated Ruby 3.2 and this will be removed at Ruby 3.3.

FYI: https://bugs.ruby-lang.org/issues/18797