### PR TITLE
Make generated code more compact

### DIFF
--- a/examples/foreign_reference/matcher.kpeg
+++ b/examples/foreign_reference/matcher.kpeg
@@ -1,7 +1,7 @@
 %% name = Matcher
 
 %% {
-	require "literals.kpeg.rb"
+	require_relative "literals.kpeg"
 }
 
 %grammer1 = Literal

--- a/examples/lua_string/driver.rb
+++ b/examples/lua_string/driver.rb
@@ -1,4 +1,4 @@
-require 'lua_string.kpeg.rb'
+require_relative 'lua_string.kpeg'
 
 ls = LuaString.new("[[blah]]")
 ls.parse

--- a/examples/phone_number/phone_number.kpeg
+++ b/examples/phone_number/phone_number.kpeg
@@ -16,5 +16,5 @@ suffix = < digit[4] > { text }
 
 phone_number = LP? area_code:ac RP? space* prefix:p space* dash? space* suffix:s space* { "(#{ac}) #{p}-#{s}" } 
 
-root = phone_number:pn { @phone_number = pn }
-		| country_code:c space* phone_number:pn { @phone_number = "+#{c} #{pn}" }
+root = country_code:c space* phone_number:pn { @phone_number = "+#{c} #{pn}" }
+		 | phone_number:pn { @phone_number = pn }

--- a/examples/phone_number/phone_number.rb
+++ b/examples/phone_number/phone_number.rb
@@ -1,6 +1,11 @@
 require 'rubygems'
 require "./phone_number.kpeg.rb"
 
-parser = PhoneNumber.new("8888888888")
-puts parser.parse
-puts parser.phone_number
+for number in ["123456789", "1234567890", "(123)4567890", "(123) 456 - 7890",
+               "7(123) 456-7890"]
+  puts number
+  parser = PhoneNumber.new(number)
+  puts parser.parse
+  puts parser.phone_number
+  puts "---"
+end

--- a/examples/tiny_markdown/tiny_markdown.kpeg.rb
+++ b/examples/tiny_markdown/tiny_markdown.kpeg.rb
@@ -18,6 +18,7 @@ class TinyMarkdown::Parser
       @result = nil
       @failed_rule = nil
       @failing_rule_offset = -1
+      @line_offsets = nil
 
       setup_foreign_grammar
     end
@@ -27,30 +28,83 @@ class TinyMarkdown::Parser
     attr_accessor :result, :pos
 
     def current_column(target=pos)
-      if c = string.rindex("\n", target-1)
-        return target - c - 1
+      if string[target] == "\n" && (c = string.rindex("\n", target-1) || -1)
+        return target - c
+      elsif c = string.rindex("\n", target)
+        return target - c
       end
 
       target + 1
     end
 
-    def current_line(target=pos)
-      cur_offset = 0
-      cur_line = 0
-
-      string.each_line do |line|
-        cur_line += 1
-        cur_offset += line.size
-        return cur_line if cur_offset >= target
+    def position_line_offsets
+      unless @position_line_offsets
+        @position_line_offsets = []
+        total = 0
+        string.each_line do |line|
+          total += line.size
+          @position_line_offsets << total
+        end
       end
+      @position_line_offsets
+    end
 
-      -1
+    if [].respond_to? :bsearch_index
+      def current_line(target=pos)
+        if line = position_line_offsets.bsearch_index {|x| x > target }
+          return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
+        end
+        raise "Target position #{target} is outside of string"
+      end
+    else
+      def current_line(target=pos)
+        if line = position_line_offsets.index {|x| x > target }
+          return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
+        end
+        raise "Target position #{target} is outside of string"
+      end
+    end
+
+    def current_character(target=pos)
+      if target < 0 || target > string.size
+        raise "Target position #{target} is outside of string"
+      elsif target == string.size
+        ""
+      else
+        string[target, 1]
+      end
+    end
+
+    KpegPosInfo = Struct.new(:pos, :lno, :col, :line, :char)
+
+    def current_pos_info(target=pos)
+      l = current_line target
+      c = current_column target
+      ln = get_line(l-1)
+      chr = string[target,1]
+      KpegPosInfo.new(target, l, c, ln, chr)
     end
 
     def lines
-      lines = []
-      string.each_line { |l| lines << l }
-      lines
+      string.lines
+    end
+
+    def get_line(no)
+      loff = position_line_offsets
+      if no < 0
+        raise "Line No is out of range: #{no} < 0"
+      elsif no >= loff.size
+        raise "Line No is out of range: #{no} >= #{loff.size}"
+      end
+      lend = loff[no]-1
+      lstart = no > 0 ? loff[no-1] : 0
+      string[lstart..lend]
     end
 
 
@@ -64,6 +118,7 @@ class TinyMarkdown::Parser
       @string = string
       @string_size = string ? string.size : 0
       @pos = pos
+      @position_line_offsets = nil
     end
 
     def show_pos
@@ -88,30 +143,22 @@ class TinyMarkdown::Parser
     end
 
     def failure_caret
-      l = current_line @failing_rule_offset
-      c = current_column @failing_rule_offset
-
-      line = lines[l-1]
-      "#{line}\n#{' ' * (c - 1)}^"
+      p = current_pos_info @failing_rule_offset
+      "#{p.line.chomp}\n#{' ' * (p.col - 1)}^"
     end
 
     def failure_character
-      l = current_line @failing_rule_offset
-      c = current_column @failing_rule_offset
-      lines[l-1][c-1, 1]
+      current_character @failing_rule_offset
     end
 
     def failure_oneline
-      l = current_line @failing_rule_offset
-      c = current_column @failing_rule_offset
-
-      char = lines[l-1][c-1, 1]
+      p = current_pos_info @failing_rule_offset
 
       if @failed_rule.kind_of? Symbol
         info = self.class::Rules[@failed_rule]
-        "@#{l}:#{c} failed rule '#{info.name}', got '#{char}'"
+        "@#{p.lno}:#{p.col} failed rule '#{info.name}', got '#{p.char}'"
       else
-        "@#{l}:#{c} failed rule '#{@failed_rule}', got '#{char}'"
+        "@#{p.lno}:#{p.col} failed rule '#{@failed_rule}', got '#{p.char}'"
       end
     end
 
@@ -124,10 +171,9 @@ class TinyMarkdown::Parser
 
     def show_error(io=STDOUT)
       error_pos = @failing_rule_offset
-      line_no = current_line(error_pos)
-      col_no = current_column(error_pos)
+      p = current_pos_info(error_pos)
 
-      io.puts "On line #{line_no}, column #{col_no}:"
+      io.puts "On line #{p.lno}, column #{p.col}:"
 
       if @failed_rule.kind_of? Symbol
         info = self.class::Rules[@failed_rule]
@@ -136,10 +182,9 @@ class TinyMarkdown::Parser
         io.puts "Failed to match rule '#{@failed_rule}'"
       end
 
-      io.puts "Got: #{string[error_pos,1].inspect}"
-      line = lines[line_no-1]
-      io.puts "=> #{line}"
-      io.print(" " * (col_no + 3))
+      io.puts "Got: #{p.char.inspect}"
+      io.puts "=> #{p.line}"
+      io.print(" " * (p.col + 2))
       io.puts "^"
     end
 
@@ -163,9 +208,8 @@ class TinyMarkdown::Parser
     end
 
     def scan(reg)
-      if m = reg.match(@string[@pos..-1])
-        width = m.end(0)
-        @pos += width
+      if m = reg.match(@string, @pos)
+        @pos = m.end(0)
         return true
       end
 
@@ -249,6 +293,7 @@ class TinyMarkdown::Parser
     end
 
     def apply_with_args(rule, *args)
+      @result = nil
       memo_key = [rule, args]
       if m = @memoizations[memo_key][@pos]
         @pos = m.pos
@@ -278,12 +323,11 @@ class TinyMarkdown::Parser
         else
           return ans
         end
-
-        return ans
       end
     end
 
     def apply(rule)
+      @result = nil
       if m = @memoizations[rule][@pos]
         @pos = m.pos
         if !m.set
@@ -312,8 +356,6 @@ class TinyMarkdown::Parser
         else
           return ans
         end
-
-        return ans
       end
     end
 
@@ -808,7 +850,7 @@ class TinyMarkdown::Parser
     _save = self.pos
     while true # sequence
       _text_start = self.pos
-      _tmp = scan(/\A(?-mix:######|#####|####|###|##|#)/)
+      _tmp = scan(/\G(?-mix:######|#####|####|###|##|#)/)
       if _tmp
         text = get_text(_text_start)
       end
@@ -2941,7 +2983,7 @@ class TinyMarkdown::Parser
     _save = self.pos
     while true # sequence
       _text_start = self.pos
-      _tmp = scan(/\A(?-mix:`)/)
+      _tmp = scan(/\G(?-mix:`)/)
       if _tmp
         text = get_text(_text_start)
       end
@@ -2975,7 +3017,7 @@ class TinyMarkdown::Parser
     _save = self.pos
     while true # sequence
       _text_start = self.pos
-      _tmp = scan(/\A(?-mix:``)/)
+      _tmp = scan(/\G(?-mix:``)/)
       if _tmp
         text = get_text(_text_start)
       end
@@ -3340,7 +3382,7 @@ class TinyMarkdown::Parser
     _save = self.pos
     while true # sequence
       _text_start = self.pos
-      _tmp = scan(/\A(?-mix: |\t)/)
+      _tmp = scan(/\G(?-mix: |\t)/)
       if _tmp
         text = get_text(_text_start)
       end
@@ -3496,7 +3538,7 @@ class TinyMarkdown::Parser
     _save = self.pos
     while true # sequence
       _text_start = self.pos
-      _tmp = scan(/\A(?-mix:[~*_`&\[\]()<!#\\'"])/)
+      _tmp = scan(/\G(?-mix:[~*_`&\[\]()<!#\\'"])/)
       if _tmp
         text = get_text(_text_start)
       end
@@ -3570,7 +3612,7 @@ class TinyMarkdown::Parser
     _save = self.pos
     while true # sequence
       _text_start = self.pos
-      _tmp = scan(/\A(?-mix:[A-Za-z0-9])/)
+      _tmp = scan(/\G(?-mix:[A-Za-z0-9])/)
       if _tmp
         text = get_text(_text_start)
       end
@@ -3596,7 +3638,7 @@ class TinyMarkdown::Parser
     _save = self.pos
     while true # sequence
       _text_start = self.pos
-      _tmp = scan(/\A(?-mix:[0-9])/)
+      _tmp = scan(/\G(?-mix:[0-9])/)
       if _tmp
         text = get_text(_text_start)
       end
@@ -3622,7 +3664,7 @@ class TinyMarkdown::Parser
     _save = self.pos
     while true # sequence
       _text_start = self.pos
-      _tmp = scan(/\A(?-mix:   |  | |)/)
+      _tmp = scan(/\G(?-mix:   |  | |)/)
       if _tmp
         text = get_text(_text_start)
       end
@@ -3648,7 +3690,7 @@ class TinyMarkdown::Parser
     _save = self.pos
     while true # sequence
       _text_start = self.pos
-      _tmp = scan(/\A(?-mix:\t|    )/)
+      _tmp = scan(/\G(?-mix:\t|    )/)
       if _tmp
         text = get_text(_text_start)
       end
@@ -3757,7 +3799,7 @@ class TinyMarkdown::Parser
         _save2 = self.pos
         while true # sequence
           _text_start = self.pos
-          _tmp = scan(/\A(?-mix:[^\r\n]*)/)
+          _tmp = scan(/\G(?-mix:[^\r\n]*)/)
           if _tmp
             text = get_text(_text_start)
           end
@@ -3784,7 +3826,7 @@ class TinyMarkdown::Parser
         _save3 = self.pos
         while true # sequence
           _text_start = self.pos
-          _tmp = scan(/\A(?-mix:.+)/)
+          _tmp = scan(/\G(?-mix:.+)/)
           if _tmp
             text = get_text(_text_start)
           end

--- a/examples/tiny_markdown/tiny_markdown.kpeg.rb
+++ b/examples/tiny_markdown/tiny_markdown.kpeg.rb
@@ -193,6 +193,7 @@ class TinyMarkdown::Parser
         @failed_rule = name
         @failing_rule_offset = @pos
       end
+      nil
     end
 
     attr_reader :failed_rule
@@ -235,6 +236,32 @@ class TinyMarkdown::Parser
         s = @string[@pos]
         @pos += 1
         s
+      end
+    end
+
+    def look_ahead(pos, action)
+      @pos = pos
+      action ? true : nil
+    end
+
+    def loop_range(range, store)
+      _ary = [] if store
+      max = range.end && range.max
+      count = 0
+      save = @pos
+      while (!max || count < max) && yield
+        count += 1
+        if store
+          _ary << @result
+          @result = nil
+        end
+      end
+      if range.include?(count)
+        @result = _ary if store
+        true
+      else
+        @pos = save
+        nil
       end
     end
 
@@ -595,3278 +622,1096 @@ class TinyMarkdown::Parser
 
   # root = Start
   def _root
-    _tmp = apply(:_Start)
-    set_failed_rule :_root unless _tmp
-    return _tmp
+    apply(:_Start) or set_failed_rule :_root
   end
 
   # Start = &. Doc:c { @ast = c  }
   def _Start
-
-    _save = self.pos
-    while true # sequence
-      _save1 = self.pos
-      _tmp = get_byte
-      self.pos = _save1
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = apply(:_Doc)
-      c = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  @ast = c  ; end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_Start unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      ( _save1 = self.pos
+        look_ahead(_save1,
+          get_byte  # end look ahead
+      )) &&
+      apply(:_Doc) &&
+      ( c = @result; true ) &&
+      ( @result = (@ast = c); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_Start
   end
 
   # Doc = Block*:c {document(self, position, c)}
   def _Doc
-
-    _save = self.pos
-    while true # sequence
-      _ary = []
-      while true
-        _tmp = apply(:_Block)
-        _ary << @result if _tmp
-        break unless _tmp
-      end
-      _tmp = true
-      @result = _ary
-      c = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin; document(self, position, c); end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_Doc unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      loop_range(0.., true) {
+        apply(:_Block)
+      } &&
+      ( c = @result; true ) &&
+      ( @result = (document(self, position, c)); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_Doc
   end
 
   # Block = BlankLine* (BlockQuote | Verbatim | HorizontalRule | Heading | BulletList | Para | Plain)
   def _Block
-
-    _save = self.pos
-    while true # sequence
-      while true
-        _tmp = apply(:_BlankLine)
-        break unless _tmp
-      end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-        break
-      end
-
-      _save2 = self.pos
-      while true # choice
-        _tmp = apply(:_BlockQuote)
-        break if _tmp
-        self.pos = _save2
-        _tmp = apply(:_Verbatim)
-        break if _tmp
-        self.pos = _save2
-        _tmp = apply(:_HorizontalRule)
-        break if _tmp
-        self.pos = _save2
-        _tmp = apply(:_Heading)
-        break if _tmp
-        self.pos = _save2
-        _tmp = apply(:_BulletList)
-        break if _tmp
-        self.pos = _save2
-        _tmp = apply(:_Para)
-        break if _tmp
-        self.pos = _save2
-        _tmp = apply(:_Plain)
-        break if _tmp
-        self.pos = _save2
-        break
-      end # end choice
-
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_Block unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      while true  # kleene
+        apply(:_BlankLine) || (break true) # end kleene
+      end &&
+      ( # choice
+        apply(:_BlockQuote) ||
+        apply(:_Verbatim) ||
+        apply(:_HorizontalRule) ||
+        apply(:_Heading) ||
+        apply(:_BulletList) ||
+        apply(:_Para) ||
+        apply(:_Plain)
+        # end choice
+      ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_Block
   end
 
   # Para = NonindentSpace Inlines:a BlankLine+ {para(self, position, a)}
   def _Para
-
-    _save = self.pos
-    while true # sequence
-      _tmp = apply(:_NonindentSpace)
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = apply(:_Inlines)
-      a = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save1 = self.pos
-      _tmp = apply(:_BlankLine)
-      if _tmp
-        while true
-          _tmp = apply(:_BlankLine)
-          break unless _tmp
-        end
-        _tmp = true
-      else
-        self.pos = _save1
-      end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin; para(self, position, a); end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_Para unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      apply(:_NonindentSpace) &&
+      apply(:_Inlines) &&
+      ( a = @result; true ) &&
+      loop_range(1.., false) {
+        apply(:_BlankLine)
+      } &&
+      ( @result = (para(self, position, a)); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_Para
   end
 
   # Plain = Inlines:a {plain(self, position, a)}
   def _Plain
-
-    _save = self.pos
-    while true # sequence
-      _tmp = apply(:_Inlines)
-      a = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin; plain(self, position, a); end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_Plain unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      apply(:_Inlines) &&
+      ( a = @result; true ) &&
+      ( @result = (plain(self, position, a)); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_Plain
   end
 
   # AtxInline = !Newline !(Sp "#"* Sp Newline) Inline:c { c }
   def _AtxInline
-
-    _save = self.pos
-    while true # sequence
-      _save1 = self.pos
-      _tmp = apply(:_Newline)
-      _tmp = _tmp ? nil : true
-      self.pos = _save1
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save2 = self.pos
-
-      _save3 = self.pos
-      while true # sequence
-        _tmp = apply(:_Sp)
-        unless _tmp
-          self.pos = _save3
-          break
-        end
-        while true
-          _tmp = match_string("#")
-          break unless _tmp
-        end
-        _tmp = true
-        unless _tmp
-          self.pos = _save3
-          break
-        end
-        _tmp = apply(:_Sp)
-        unless _tmp
-          self.pos = _save3
-          break
-        end
-        _tmp = apply(:_Newline)
-        unless _tmp
-          self.pos = _save3
-        end
-        break
-      end # end sequence
-
-      _tmp = _tmp ? nil : true
-      self.pos = _save2
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = apply(:_Inline)
-      c = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  c ; end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_AtxInline unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      ( _save1 = self.pos
+        look_ahead(_save1, !(
+          apply(:_Newline)  # end negation
+      ))) &&
+      ( _save2 = self.pos
+        look_ahead(_save2, !(
+          ( _save3 = self.pos  # sequence
+            apply(:_Sp) &&
+            while true  # kleene
+              match_string("#") || (break true) # end kleene
+            end &&
+            apply(:_Sp) &&
+            apply(:_Newline) ||
+            ( self.pos = _save3; nil )  # end sequence
+          )  # end negation
+      ))) &&
+      apply(:_Inline) &&
+      ( c = @result; true ) &&
+      ( @result = (c); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_AtxInline
   end
 
   # AtxStart = < /######|#####|####|###|##|#/ > { text.length }
   def _AtxStart
-
-    _save = self.pos
-    while true # sequence
-      _text_start = self.pos
-      _tmp = scan(/\G(?-mix:######|#####|####|###|##|#)/)
-      if _tmp
-        text = get_text(_text_start)
-      end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  text.length ; end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_AtxStart unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      ( _text_start = self.pos
+        scan(/\G(?-mix:######|#####|####|###|##|#)/) &&
+        ( text = get_text(_text_start); true )
+      ) &&
+      ( @result = (text.length); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_AtxStart
   end
 
   # AtxHeading = AtxStart:level Sp AtxInline+:c (Sp "#"* Sp)? Newline {headline(self, position, level, c)}
   def _AtxHeading
-
-    _save = self.pos
-    while true # sequence
-      _tmp = apply(:_AtxStart)
-      level = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = apply(:_Sp)
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save1 = self.pos
-      _ary = []
-      _tmp = apply(:_AtxInline)
-      if _tmp
-        _ary << @result
-        while true
-          _tmp = apply(:_AtxInline)
-          _ary << @result if _tmp
-          break unless _tmp
-        end
-        _tmp = true
-        @result = _ary
-      else
-        self.pos = _save1
-      end
-      c = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save2 = self.pos
-
-      _save3 = self.pos
-      while true # sequence
-        _tmp = apply(:_Sp)
-        unless _tmp
-          self.pos = _save3
-          break
-        end
-        while true
-          _tmp = match_string("#")
-          break unless _tmp
-        end
-        _tmp = true
-        unless _tmp
-          self.pos = _save3
-          break
-        end
-        _tmp = apply(:_Sp)
-        unless _tmp
-          self.pos = _save3
-        end
-        break
-      end # end sequence
-
-      unless _tmp
-        _tmp = true
-        self.pos = _save2
-      end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = apply(:_Newline)
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin; headline(self, position, level, c); end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_AtxHeading unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      apply(:_AtxStart) &&
+      ( level = @result; true ) &&
+      apply(:_Sp) &&
+      loop_range(1.., true) {
+        apply(:_AtxInline)
+      } &&
+      ( c = @result; true ) &&
+      ( _save1 = self.pos  # optional
+        ( _save2 = self.pos  # sequence
+          apply(:_Sp) &&
+          while true  # kleene
+            match_string("#") || (break true) # end kleene
+          end &&
+          apply(:_Sp) ||
+          ( self.pos = _save2; nil )  # end sequence
+        ) ||
+        ( self.pos = _save1; true )  # end optional
+      ) &&
+      apply(:_Newline) &&
+      ( @result = (headline(self, position, level, c)); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_AtxHeading
   end
 
   # Heading = AtxHeading
   def _Heading
-    _tmp = apply(:_AtxHeading)
-    set_failed_rule :_Heading unless _tmp
-    return _tmp
+    apply(:_AtxHeading) or set_failed_rule :_Heading
   end
 
   # BlockQuote = BlockQuoteRaw:c {block_quote(self, position, c)}
   def _BlockQuote
-
-    _save = self.pos
-    while true # sequence
-      _tmp = apply(:_BlockQuoteRaw)
-      c = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin; block_quote(self, position, c); end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_BlockQuote unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      apply(:_BlockQuoteRaw) &&
+      ( c = @result; true ) &&
+      ( @result = (block_quote(self, position, c)); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_BlockQuote
   end
 
   # BlockQuoteRaw = (">" " "? Line:c { c })+:cc { cc }
   def _BlockQuoteRaw
-
-    _save = self.pos
-    while true # sequence
-      _save1 = self.pos
-      _ary = []
-
-      _save2 = self.pos
-      while true # sequence
-        _tmp = match_string(">")
-        unless _tmp
-          self.pos = _save2
-          break
-        end
-        _save3 = self.pos
-        _tmp = match_string(" ")
-        unless _tmp
-          _tmp = true
-          self.pos = _save3
-        end
-        unless _tmp
-          self.pos = _save2
-          break
-        end
-        _tmp = apply(:_Line)
-        c = @result
-        unless _tmp
-          self.pos = _save2
-          break
-        end
-        @result = begin;  c ; end
-        _tmp = true
-        unless _tmp
-          self.pos = _save2
-        end
-        break
-      end # end sequence
-
-      if _tmp
-        _ary << @result
-        while true
-
-          _save4 = self.pos
-          while true # sequence
-            _tmp = match_string(">")
-            unless _tmp
-              self.pos = _save4
-              break
-            end
-            _save5 = self.pos
-            _tmp = match_string(" ")
-            unless _tmp
-              _tmp = true
-              self.pos = _save5
-            end
-            unless _tmp
-              self.pos = _save4
-              break
-            end
-            _tmp = apply(:_Line)
-            c = @result
-            unless _tmp
-              self.pos = _save4
-              break
-            end
-            @result = begin;  c ; end
-            _tmp = true
-            unless _tmp
-              self.pos = _save4
-            end
-            break
-          end # end sequence
-
-          _ary << @result if _tmp
-          break unless _tmp
-        end
-        _tmp = true
-        @result = _ary
-      else
-        self.pos = _save1
-      end
-      cc = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  cc ; end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_BlockQuoteRaw unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      loop_range(1.., true) {
+        ( _save1 = self.pos  # sequence
+          match_string(">") &&
+          ( _save2 = self.pos  # optional
+            match_string(" ") ||
+            ( self.pos = _save2; true )  # end optional
+          ) &&
+          apply(:_Line) &&
+          ( c = @result; true ) &&
+          ( @result = (c); true ) ||
+          ( self.pos = _save1; nil )  # end sequence
+        )
+      } &&
+      ( cc = @result; true ) &&
+      ( @result = (cc); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_BlockQuoteRaw
   end
 
   # NonblankIndentedLine = !BlankLine IndentedLine:c { c }
   def _NonblankIndentedLine
-
-    _save = self.pos
-    while true # sequence
-      _save1 = self.pos
-      _tmp = apply(:_BlankLine)
-      _tmp = _tmp ? nil : true
-      self.pos = _save1
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = apply(:_IndentedLine)
-      c = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  c ; end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_NonblankIndentedLine unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      ( _save1 = self.pos
+        look_ahead(_save1, !(
+          apply(:_BlankLine)  # end negation
+      ))) &&
+      apply(:_IndentedLine) &&
+      ( c = @result; true ) &&
+      ( @result = (c); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_NonblankIndentedLine
   end
 
   # VerbatimChunk = (BlankLine { text(self,position,"\n") })*:c1 (NonblankIndentedLine:c { [c, text(self,position,"\n")] })+:c2 { c1 + c2.flatten }
   def _VerbatimChunk
-
-    _save = self.pos
-    while true # sequence
-      _ary = []
-      while true
-
-        _save2 = self.pos
-        while true # sequence
-          _tmp = apply(:_BlankLine)
-          unless _tmp
-            self.pos = _save2
-            break
-          end
-          @result = begin;  text(self,position,"\n") ; end
-          _tmp = true
-          unless _tmp
-            self.pos = _save2
-          end
-          break
-        end # end sequence
-
-        _ary << @result if _tmp
-        break unless _tmp
-      end
-      _tmp = true
-      @result = _ary
-      c1 = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save3 = self.pos
-      _ary = []
-
-      _save4 = self.pos
-      while true # sequence
-        _tmp = apply(:_NonblankIndentedLine)
-        c = @result
-        unless _tmp
-          self.pos = _save4
-          break
-        end
-        @result = begin;  [c, text(self,position,"\n")] ; end
-        _tmp = true
-        unless _tmp
-          self.pos = _save4
-        end
-        break
-      end # end sequence
-
-      if _tmp
-        _ary << @result
-        while true
-
-          _save5 = self.pos
-          while true # sequence
-            _tmp = apply(:_NonblankIndentedLine)
-            c = @result
-            unless _tmp
-              self.pos = _save5
-              break
-            end
-            @result = begin;  [c, text(self,position,"\n")] ; end
-            _tmp = true
-            unless _tmp
-              self.pos = _save5
-            end
-            break
-          end # end sequence
-
-          _ary << @result if _tmp
-          break unless _tmp
-        end
-        _tmp = true
-        @result = _ary
-      else
-        self.pos = _save3
-      end
-      c2 = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  c1 + c2.flatten ; end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_VerbatimChunk unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      loop_range(0.., true) {
+        ( _save1 = self.pos  # sequence
+          apply(:_BlankLine) &&
+          ( @result = (text(self,position,"\n")); true ) ||
+          ( self.pos = _save1; nil )  # end sequence
+        )
+      } &&
+      ( c1 = @result; true ) &&
+      loop_range(1.., true) {
+        ( _save2 = self.pos  # sequence
+          apply(:_NonblankIndentedLine) &&
+          ( c = @result; true ) &&
+          ( @result = ([c, text(self,position,"\n")]); true ) ||
+          ( self.pos = _save2; nil )  # end sequence
+        )
+      } &&
+      ( c2 = @result; true ) &&
+      ( @result = (c1 + c2.flatten); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_VerbatimChunk
   end
 
   # Verbatim = VerbatimChunk+:cc {verbatim(self, position, cc.flatten)}
   def _Verbatim
-
-    _save = self.pos
-    while true # sequence
-      _save1 = self.pos
-      _ary = []
-      _tmp = apply(:_VerbatimChunk)
-      if _tmp
-        _ary << @result
-        while true
-          _tmp = apply(:_VerbatimChunk)
-          _ary << @result if _tmp
-          break unless _tmp
-        end
-        _tmp = true
-        @result = _ary
-      else
-        self.pos = _save1
-      end
-      cc = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin; verbatim(self, position, cc.flatten); end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_Verbatim unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      loop_range(1.., true) {
+        apply(:_VerbatimChunk)
+      } &&
+      ( cc = @result; true ) &&
+      ( @result = (verbatim(self, position, cc.flatten)); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_Verbatim
   end
 
   # HorizontalRule = NonindentSpace ("*" Sp "*" Sp "*" (Sp "*")* | "-" Sp "-" Sp "-" (Sp "-")* | "_" Sp "_" Sp "_" (Sp "_")*) Sp Newline BlankLine+ {horizontal_rule(self, position)}
   def _HorizontalRule
-
-    _save = self.pos
-    while true # sequence
-      _tmp = apply(:_NonindentSpace)
-      unless _tmp
-        self.pos = _save
-        break
-      end
-
-      _save1 = self.pos
-      while true # choice
-
-        _save2 = self.pos
-        while true # sequence
-          _tmp = match_string("*")
-          unless _tmp
-            self.pos = _save2
-            break
-          end
-          _tmp = apply(:_Sp)
-          unless _tmp
-            self.pos = _save2
-            break
-          end
-          _tmp = match_string("*")
-          unless _tmp
-            self.pos = _save2
-            break
-          end
-          _tmp = apply(:_Sp)
-          unless _tmp
-            self.pos = _save2
-            break
-          end
-          _tmp = match_string("*")
-          unless _tmp
-            self.pos = _save2
-            break
-          end
-          while true
-
-            _save4 = self.pos
-            while true # sequence
-              _tmp = apply(:_Sp)
-              unless _tmp
-                self.pos = _save4
-                break
-              end
-              _tmp = match_string("*")
-              unless _tmp
-                self.pos = _save4
-              end
-              break
-            end # end sequence
-
-            break unless _tmp
-          end
-          _tmp = true
-          unless _tmp
-            self.pos = _save2
-          end
-          break
-        end # end sequence
-
-        break if _tmp
-        self.pos = _save1
-
-        _save5 = self.pos
-        while true # sequence
-          _tmp = match_string("-")
-          unless _tmp
-            self.pos = _save5
-            break
-          end
-          _tmp = apply(:_Sp)
-          unless _tmp
-            self.pos = _save5
-            break
-          end
-          _tmp = match_string("-")
-          unless _tmp
-            self.pos = _save5
-            break
-          end
-          _tmp = apply(:_Sp)
-          unless _tmp
-            self.pos = _save5
-            break
-          end
-          _tmp = match_string("-")
-          unless _tmp
-            self.pos = _save5
-            break
-          end
-          while true
-
-            _save7 = self.pos
-            while true # sequence
-              _tmp = apply(:_Sp)
-              unless _tmp
-                self.pos = _save7
-                break
-              end
-              _tmp = match_string("-")
-              unless _tmp
-                self.pos = _save7
-              end
-              break
-            end # end sequence
-
-            break unless _tmp
-          end
-          _tmp = true
-          unless _tmp
-            self.pos = _save5
-          end
-          break
-        end # end sequence
-
-        break if _tmp
-        self.pos = _save1
-
-        _save8 = self.pos
-        while true # sequence
-          _tmp = match_string("_")
-          unless _tmp
-            self.pos = _save8
-            break
-          end
-          _tmp = apply(:_Sp)
-          unless _tmp
-            self.pos = _save8
-            break
-          end
-          _tmp = match_string("_")
-          unless _tmp
-            self.pos = _save8
-            break
-          end
-          _tmp = apply(:_Sp)
-          unless _tmp
-            self.pos = _save8
-            break
-          end
-          _tmp = match_string("_")
-          unless _tmp
-            self.pos = _save8
-            break
-          end
-          while true
-
-            _save10 = self.pos
-            while true # sequence
-              _tmp = apply(:_Sp)
-              unless _tmp
-                self.pos = _save10
-                break
-              end
-              _tmp = match_string("_")
-              unless _tmp
-                self.pos = _save10
-              end
-              break
-            end # end sequence
-
-            break unless _tmp
-          end
-          _tmp = true
-          unless _tmp
-            self.pos = _save8
-          end
-          break
-        end # end sequence
-
-        break if _tmp
-        self.pos = _save1
-        break
-      end # end choice
-
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = apply(:_Sp)
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = apply(:_Newline)
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save11 = self.pos
-      _tmp = apply(:_BlankLine)
-      if _tmp
-        while true
-          _tmp = apply(:_BlankLine)
-          break unless _tmp
-        end
-        _tmp = true
-      else
-        self.pos = _save11
-      end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin; horizontal_rule(self, position); end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_HorizontalRule unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      apply(:_NonindentSpace) &&
+      ( # choice
+        ( _save1 = self.pos  # sequence
+          match_string("*") &&
+          apply(:_Sp) &&
+          match_string("*") &&
+          apply(:_Sp) &&
+          match_string("*") &&
+          while true  # kleene
+            ( _save2 = self.pos  # sequence
+              apply(:_Sp) &&
+              match_string("*") ||
+              ( self.pos = _save2; nil )  # end sequence
+            ) || (break true) # end kleene
+          end ||
+          ( self.pos = _save1; nil )  # end sequence
+        ) ||
+        ( _save3 = self.pos  # sequence
+          match_string("-") &&
+          apply(:_Sp) &&
+          match_string("-") &&
+          apply(:_Sp) &&
+          match_string("-") &&
+          while true  # kleene
+            ( _save4 = self.pos  # sequence
+              apply(:_Sp) &&
+              match_string("-") ||
+              ( self.pos = _save4; nil )  # end sequence
+            ) || (break true) # end kleene
+          end ||
+          ( self.pos = _save3; nil )  # end sequence
+        ) ||
+        ( _save5 = self.pos  # sequence
+          match_string("_") &&
+          apply(:_Sp) &&
+          match_string("_") &&
+          apply(:_Sp) &&
+          match_string("_") &&
+          while true  # kleene
+            ( _save6 = self.pos  # sequence
+              apply(:_Sp) &&
+              match_string("_") ||
+              ( self.pos = _save6; nil )  # end sequence
+            ) || (break true) # end kleene
+          end ||
+          ( self.pos = _save5; nil )  # end sequence
+        )
+        # end choice
+      ) &&
+      apply(:_Sp) &&
+      apply(:_Newline) &&
+      loop_range(1.., false) {
+        apply(:_BlankLine)
+      } &&
+      ( @result = (horizontal_rule(self, position)); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_HorizontalRule
   end
 
   # Bullet = !HorizontalRule NonindentSpace ("+" | "*" | "-") Spacechar+
   def _Bullet
-
-    _save = self.pos
-    while true # sequence
-      _save1 = self.pos
-      _tmp = apply(:_HorizontalRule)
-      _tmp = _tmp ? nil : true
-      self.pos = _save1
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = apply(:_NonindentSpace)
-      unless _tmp
-        self.pos = _save
-        break
-      end
-
-      _save2 = self.pos
-      while true # choice
-        _tmp = match_string("+")
-        break if _tmp
-        self.pos = _save2
-        _tmp = match_string("*")
-        break if _tmp
-        self.pos = _save2
-        _tmp = match_string("-")
-        break if _tmp
-        self.pos = _save2
-        break
-      end # end choice
-
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save3 = self.pos
-      _tmp = apply(:_Spacechar)
-      if _tmp
-        while true
-          _tmp = apply(:_Spacechar)
-          break unless _tmp
-        end
-        _tmp = true
-      else
-        self.pos = _save3
-      end
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_Bullet unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      ( _save1 = self.pos
+        look_ahead(_save1, !(
+          apply(:_HorizontalRule)  # end negation
+      ))) &&
+      apply(:_NonindentSpace) &&
+      ( # choice
+        match_string("+") ||
+        match_string("*") ||
+        match_string("-")
+        # end choice
+      ) &&
+      loop_range(1.., false) {
+        apply(:_Spacechar)
+      } ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_Bullet
   end
 
   # BulletList = &Bullet ListTight:c {bullet_list(self, position, c)}
   def _BulletList
-
-    _save = self.pos
-    while true # sequence
-      _save1 = self.pos
-      _tmp = apply(:_Bullet)
-      self.pos = _save1
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = apply(:_ListTight)
-      c = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin; bullet_list(self, position, c); end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_BulletList unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      ( _save1 = self.pos
+        look_ahead(_save1,
+          apply(:_Bullet)  # end look ahead
+      )) &&
+      apply(:_ListTight) &&
+      ( c = @result; true ) &&
+      ( @result = (bullet_list(self, position, c)); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_BulletList
   end
 
   # ListTight = ListItemTight+:cc BlankLine* !Bullet { cc }
   def _ListTight
-
-    _save = self.pos
-    while true # sequence
-      _save1 = self.pos
-      _ary = []
-      _tmp = apply(:_ListItemTight)
-      if _tmp
-        _ary << @result
-        while true
-          _tmp = apply(:_ListItemTight)
-          _ary << @result if _tmp
-          break unless _tmp
-        end
-        _tmp = true
-        @result = _ary
-      else
-        self.pos = _save1
-      end
-      cc = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      while true
-        _tmp = apply(:_BlankLine)
-        break unless _tmp
-      end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save3 = self.pos
-      _tmp = apply(:_Bullet)
-      _tmp = _tmp ? nil : true
-      self.pos = _save3
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  cc ; end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_ListTight unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      loop_range(1.., true) {
+        apply(:_ListItemTight)
+      } &&
+      ( cc = @result; true ) &&
+      while true  # kleene
+        apply(:_BlankLine) || (break true) # end kleene
+      end &&
+      ( _save1 = self.pos
+        look_ahead(_save1, !(
+          apply(:_Bullet)  # end negation
+      ))) &&
+      ( @result = (cc); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_ListTight
   end
 
   # ListItemTight = Bullet ListBlock:c {bullet_list_item(self, position, c)}
   def _ListItemTight
-
-    _save = self.pos
-    while true # sequence
-      _tmp = apply(:_Bullet)
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = apply(:_ListBlock)
-      c = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin; bullet_list_item(self, position, c); end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_ListItemTight unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      apply(:_Bullet) &&
+      apply(:_ListBlock) &&
+      ( c = @result; true ) &&
+      ( @result = (bullet_list_item(self, position, c)); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_ListItemTight
   end
 
   # ListBlock = !BlankLine Line:c ListBlockLine*:cc { cc.unshift(c) }
   def _ListBlock
-
-    _save = self.pos
-    while true # sequence
-      _save1 = self.pos
-      _tmp = apply(:_BlankLine)
-      _tmp = _tmp ? nil : true
-      self.pos = _save1
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = apply(:_Line)
-      c = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _ary = []
-      while true
-        _tmp = apply(:_ListBlockLine)
-        _ary << @result if _tmp
-        break unless _tmp
-      end
-      _tmp = true
-      @result = _ary
-      cc = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  cc.unshift(c) ; end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_ListBlock unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      ( _save1 = self.pos
+        look_ahead(_save1, !(
+          apply(:_BlankLine)  # end negation
+      ))) &&
+      apply(:_Line) &&
+      ( c = @result; true ) &&
+      loop_range(0.., true) {
+        apply(:_ListBlockLine)
+      } &&
+      ( cc = @result; true ) &&
+      ( @result = (cc.unshift(c)); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_ListBlock
   end
 
   # ListBlockLine = !BlankLine !(Indent? Bullet) !HorizontalRule OptionallyIndentedLine
   def _ListBlockLine
-
-    _save = self.pos
-    while true # sequence
-      _save1 = self.pos
-      _tmp = apply(:_BlankLine)
-      _tmp = _tmp ? nil : true
-      self.pos = _save1
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save2 = self.pos
-
-      _save3 = self.pos
-      while true # sequence
-        _save4 = self.pos
-        _tmp = apply(:_Indent)
-        unless _tmp
-          _tmp = true
-          self.pos = _save4
-        end
-        unless _tmp
-          self.pos = _save3
-          break
-        end
-        _tmp = apply(:_Bullet)
-        unless _tmp
-          self.pos = _save3
-        end
-        break
-      end # end sequence
-
-      _tmp = _tmp ? nil : true
-      self.pos = _save2
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save5 = self.pos
-      _tmp = apply(:_HorizontalRule)
-      _tmp = _tmp ? nil : true
-      self.pos = _save5
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = apply(:_OptionallyIndentedLine)
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_ListBlockLine unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      ( _save1 = self.pos
+        look_ahead(_save1, !(
+          apply(:_BlankLine)  # end negation
+      ))) &&
+      ( _save2 = self.pos
+        look_ahead(_save2, !(
+          ( _save3 = self.pos  # sequence
+            ( _save4 = self.pos  # optional
+              apply(:_Indent) ||
+              ( self.pos = _save4; true )  # end optional
+            ) &&
+            apply(:_Bullet) ||
+            ( self.pos = _save3; nil )  # end sequence
+          )  # end negation
+      ))) &&
+      ( _save5 = self.pos
+        look_ahead(_save5, !(
+          apply(:_HorizontalRule)  # end negation
+      ))) &&
+      apply(:_OptionallyIndentedLine) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_ListBlockLine
   end
 
   # Inlines = (!Endline Inline:c { c } | Endline:c &Inline { c })+:cc Endline? { cc }
   def _Inlines
-
-    _save = self.pos
-    while true # sequence
-      _save1 = self.pos
-      _ary = []
-
-      _save2 = self.pos
-      while true # choice
-
-        _save3 = self.pos
-        while true # sequence
-          _save4 = self.pos
-          _tmp = apply(:_Endline)
-          _tmp = _tmp ? nil : true
-          self.pos = _save4
-          unless _tmp
-            self.pos = _save3
-            break
-          end
-          _tmp = apply(:_Inline)
-          c = @result
-          unless _tmp
-            self.pos = _save3
-            break
-          end
-          @result = begin;  c ; end
-          _tmp = true
-          unless _tmp
-            self.pos = _save3
-          end
-          break
-        end # end sequence
-
-        break if _tmp
-        self.pos = _save2
-
-        _save5 = self.pos
-        while true # sequence
-          _tmp = apply(:_Endline)
-          c = @result
-          unless _tmp
-            self.pos = _save5
-            break
-          end
-          _save6 = self.pos
-          _tmp = apply(:_Inline)
-          self.pos = _save6
-          unless _tmp
-            self.pos = _save5
-            break
-          end
-          @result = begin;  c ; end
-          _tmp = true
-          unless _tmp
-            self.pos = _save5
-          end
-          break
-        end # end sequence
-
-        break if _tmp
-        self.pos = _save2
-        break
-      end # end choice
-
-      if _tmp
-        _ary << @result
-        while true
-
-          _save7 = self.pos
-          while true # choice
-
-            _save8 = self.pos
-            while true # sequence
-              _save9 = self.pos
-              _tmp = apply(:_Endline)
-              _tmp = _tmp ? nil : true
-              self.pos = _save9
-              unless _tmp
-                self.pos = _save8
-                break
-              end
-              _tmp = apply(:_Inline)
-              c = @result
-              unless _tmp
-                self.pos = _save8
-                break
-              end
-              @result = begin;  c ; end
-              _tmp = true
-              unless _tmp
-                self.pos = _save8
-              end
-              break
-            end # end sequence
-
-            break if _tmp
-            self.pos = _save7
-
-            _save10 = self.pos
-            while true # sequence
-              _tmp = apply(:_Endline)
-              c = @result
-              unless _tmp
-                self.pos = _save10
-                break
-              end
-              _save11 = self.pos
-              _tmp = apply(:_Inline)
-              self.pos = _save11
-              unless _tmp
-                self.pos = _save10
-                break
-              end
-              @result = begin;  c ; end
-              _tmp = true
-              unless _tmp
-                self.pos = _save10
-              end
-              break
-            end # end sequence
-
-            break if _tmp
-            self.pos = _save7
-            break
-          end # end choice
-
-          _ary << @result if _tmp
-          break unless _tmp
-        end
-        _tmp = true
-        @result = _ary
-      else
-        self.pos = _save1
-      end
-      cc = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save12 = self.pos
-      _tmp = apply(:_Endline)
-      unless _tmp
-        _tmp = true
-        self.pos = _save12
-      end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  cc ; end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_Inlines unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      loop_range(1.., true) {
+        ( # choice
+          ( _save1 = self.pos  # sequence
+            ( _save2 = self.pos
+              look_ahead(_save2, !(
+                apply(:_Endline)  # end negation
+            ))) &&
+            apply(:_Inline) &&
+            ( c = @result; true ) &&
+            ( @result = (c); true ) ||
+            ( self.pos = _save1; nil )  # end sequence
+          ) ||
+          ( _save3 = self.pos  # sequence
+            apply(:_Endline) &&
+            ( c = @result; true ) &&
+            ( _save4 = self.pos
+              look_ahead(_save4,
+                apply(:_Inline)  # end look ahead
+            )) &&
+            ( @result = (c); true ) ||
+            ( self.pos = _save3; nil )  # end sequence
+          )
+          # end choice
+        )
+      } &&
+      ( cc = @result; true ) &&
+      ( _save5 = self.pos  # optional
+        apply(:_Endline) ||
+        ( self.pos = _save5; true )  # end optional
+      ) &&
+      ( @result = (cc); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_Inlines
   end
 
   # Inline = (Str | Endline | Space | Strong | Emph | Code | Symbol)
   def _Inline
-
-    _save = self.pos
-    while true # choice
-      _tmp = apply(:_Str)
-      break if _tmp
-      self.pos = _save
-      _tmp = apply(:_Endline)
-      break if _tmp
-      self.pos = _save
-      _tmp = apply(:_Space)
-      break if _tmp
-      self.pos = _save
-      _tmp = apply(:_Strong)
-      break if _tmp
-      self.pos = _save
-      _tmp = apply(:_Emph)
-      break if _tmp
-      self.pos = _save
-      _tmp = apply(:_Code)
-      break if _tmp
-      self.pos = _save
-      _tmp = apply(:_Symbol)
-      break if _tmp
-      self.pos = _save
-      break
-    end # end choice
-
-    set_failed_rule :_Inline unless _tmp
-    return _tmp
+    ( # choice
+      apply(:_Str) ||
+      apply(:_Endline) ||
+      apply(:_Space) ||
+      apply(:_Strong) ||
+      apply(:_Emph) ||
+      apply(:_Code) ||
+      apply(:_Symbol)
+      # end choice
+    ) or set_failed_rule :_Inline
   end
 
   # Space = Spacechar+:c {text(self, position, c.join(""))}
   def _Space
-
-    _save = self.pos
-    while true # sequence
-      _save1 = self.pos
-      _ary = []
-      _tmp = apply(:_Spacechar)
-      if _tmp
-        _ary << @result
-        while true
-          _tmp = apply(:_Spacechar)
-          _ary << @result if _tmp
-          break unless _tmp
-        end
-        _tmp = true
-        @result = _ary
-      else
-        self.pos = _save1
-      end
-      c = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin; text(self, position, c.join("")); end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_Space unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      loop_range(1.., true) {
+        apply(:_Spacechar)
+      } &&
+      ( c = @result; true ) &&
+      ( @result = (text(self, position, c.join(""))); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_Space
   end
 
   # Str = NormalChar+:c1 StrChunk*:c2 {text(self, position, (c1+c2).join(""))}
   def _Str
-
-    _save = self.pos
-    while true # sequence
-      _save1 = self.pos
-      _ary = []
-      _tmp = apply(:_NormalChar)
-      if _tmp
-        _ary << @result
-        while true
-          _tmp = apply(:_NormalChar)
-          _ary << @result if _tmp
-          break unless _tmp
-        end
-        _tmp = true
-        @result = _ary
-      else
-        self.pos = _save1
-      end
-      c1 = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _ary = []
-      while true
-        _tmp = apply(:_StrChunk)
-        _ary << @result if _tmp
-        break unless _tmp
-      end
-      _tmp = true
-      @result = _ary
-      c2 = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin; text(self, position, (c1+c2).join("")); end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_Str unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      loop_range(1.., true) {
+        apply(:_NormalChar)
+      } &&
+      ( c1 = @result; true ) &&
+      loop_range(0.., true) {
+        apply(:_StrChunk)
+      } &&
+      ( c2 = @result; true ) &&
+      ( @result = (text(self, position, (c1+c2).join(""))); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_Str
   end
 
   # StrChunk = (NormalChar:c { [c] } | "_"+:c1 NormalChar:c2 { c1.push(c2) })+:cc { cc.flatten }
   def _StrChunk
-
-    _save = self.pos
-    while true # sequence
-      _save1 = self.pos
-      _ary = []
-
-      _save2 = self.pos
-      while true # choice
-
-        _save3 = self.pos
-        while true # sequence
-          _tmp = apply(:_NormalChar)
-          c = @result
-          unless _tmp
-            self.pos = _save3
-            break
-          end
-          @result = begin;  [c] ; end
-          _tmp = true
-          unless _tmp
-            self.pos = _save3
-          end
-          break
-        end # end sequence
-
-        break if _tmp
-        self.pos = _save2
-
-        _save4 = self.pos
-        while true # sequence
-          _save5 = self.pos
-          _ary = []
-          _tmp = match_string("_")
-          if _tmp
-            _ary << @result
-            while true
-              _tmp = match_string("_")
-              _ary << @result if _tmp
-              break unless _tmp
-            end
-            _tmp = true
-            @result = _ary
-          else
-            self.pos = _save5
-          end
-          c1 = @result
-          unless _tmp
-            self.pos = _save4
-            break
-          end
-          _tmp = apply(:_NormalChar)
-          c2 = @result
-          unless _tmp
-            self.pos = _save4
-            break
-          end
-          @result = begin;  c1.push(c2) ; end
-          _tmp = true
-          unless _tmp
-            self.pos = _save4
-          end
-          break
-        end # end sequence
-
-        break if _tmp
-        self.pos = _save2
-        break
-      end # end choice
-
-      if _tmp
-        _ary << @result
-        while true
-
-          _save6 = self.pos
-          while true # choice
-
-            _save7 = self.pos
-            while true # sequence
-              _tmp = apply(:_NormalChar)
-              c = @result
-              unless _tmp
-                self.pos = _save7
-                break
-              end
-              @result = begin;  [c] ; end
-              _tmp = true
-              unless _tmp
-                self.pos = _save7
-              end
-              break
-            end # end sequence
-
-            break if _tmp
-            self.pos = _save6
-
-            _save8 = self.pos
-            while true # sequence
-              _save9 = self.pos
-              _ary = []
-              _tmp = match_string("_")
-              if _tmp
-                _ary << @result
-                while true
-                  _tmp = match_string("_")
-                  _ary << @result if _tmp
-                  break unless _tmp
-                end
-                _tmp = true
-                @result = _ary
-              else
-                self.pos = _save9
-              end
-              c1 = @result
-              unless _tmp
-                self.pos = _save8
-                break
-              end
-              _tmp = apply(:_NormalChar)
-              c2 = @result
-              unless _tmp
-                self.pos = _save8
-                break
-              end
-              @result = begin;  c1.push(c2) ; end
-              _tmp = true
-              unless _tmp
-                self.pos = _save8
-              end
-              break
-            end # end sequence
-
-            break if _tmp
-            self.pos = _save6
-            break
-          end # end choice
-
-          _ary << @result if _tmp
-          break unless _tmp
-        end
-        _tmp = true
-        @result = _ary
-      else
-        self.pos = _save1
-      end
-      cc = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  cc.flatten ; end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_StrChunk unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      loop_range(1.., true) {
+        ( # choice
+          ( _save1 = self.pos  # sequence
+            apply(:_NormalChar) &&
+            ( c = @result; true ) &&
+            ( @result = ([c]); true ) ||
+            ( self.pos = _save1; nil )  # end sequence
+          ) ||
+          ( _save2 = self.pos  # sequence
+            loop_range(1.., true) {
+              match_string("_")
+            } &&
+            ( c1 = @result; true ) &&
+            apply(:_NormalChar) &&
+            ( c2 = @result; true ) &&
+            ( @result = (c1.push(c2)); true ) ||
+            ( self.pos = _save2; nil )  # end sequence
+          )
+          # end choice
+        )
+      } &&
+      ( cc = @result; true ) &&
+      ( @result = (cc.flatten); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_StrChunk
   end
 
   # Endline = (LineBreak | TerminalEndline | NormalEndline)
   def _Endline
-
-    _save = self.pos
-    while true # choice
-      _tmp = apply(:_LineBreak)
-      break if _tmp
-      self.pos = _save
-      _tmp = apply(:_TerminalEndline)
-      break if _tmp
-      self.pos = _save
-      _tmp = apply(:_NormalEndline)
-      break if _tmp
-      self.pos = _save
-      break
-    end # end choice
-
-    set_failed_rule :_Endline unless _tmp
-    return _tmp
+    ( # choice
+      apply(:_LineBreak) ||
+      apply(:_TerminalEndline) ||
+      apply(:_NormalEndline)
+      # end choice
+    ) or set_failed_rule :_Endline
   end
 
   # NormalEndline = Sp Newline !BlankLine !">" !AtxStart !(Line ("="+ | "-"+) Newline) {text(self, position, "\n")}
   def _NormalEndline
-
-    _save = self.pos
-    while true # sequence
-      _tmp = apply(:_Sp)
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = apply(:_Newline)
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save1 = self.pos
-      _tmp = apply(:_BlankLine)
-      _tmp = _tmp ? nil : true
-      self.pos = _save1
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save2 = self.pos
-      _tmp = match_string(">")
-      _tmp = _tmp ? nil : true
-      self.pos = _save2
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save3 = self.pos
-      _tmp = apply(:_AtxStart)
-      _tmp = _tmp ? nil : true
-      self.pos = _save3
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save4 = self.pos
-
-      _save5 = self.pos
-      while true # sequence
-        _tmp = apply(:_Line)
-        unless _tmp
-          self.pos = _save5
-          break
-        end
-
-        _save6 = self.pos
-        while true # choice
-          _save7 = self.pos
-          _tmp = match_string("=")
-          if _tmp
-            while true
-              _tmp = match_string("=")
-              break unless _tmp
-            end
-            _tmp = true
-          else
-            self.pos = _save7
-          end
-          break if _tmp
-          self.pos = _save6
-          _save8 = self.pos
-          _tmp = match_string("-")
-          if _tmp
-            while true
-              _tmp = match_string("-")
-              break unless _tmp
-            end
-            _tmp = true
-          else
-            self.pos = _save8
-          end
-          break if _tmp
-          self.pos = _save6
-          break
-        end # end choice
-
-        unless _tmp
-          self.pos = _save5
-          break
-        end
-        _tmp = apply(:_Newline)
-        unless _tmp
-          self.pos = _save5
-        end
-        break
-      end # end sequence
-
-      _tmp = _tmp ? nil : true
-      self.pos = _save4
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin; text(self, position, "\n"); end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_NormalEndline unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      apply(:_Sp) &&
+      apply(:_Newline) &&
+      ( _save1 = self.pos
+        look_ahead(_save1, !(
+          apply(:_BlankLine)  # end negation
+      ))) &&
+      ( _save2 = self.pos
+        look_ahead(_save2, !(
+          match_string(">")  # end negation
+      ))) &&
+      ( _save3 = self.pos
+        look_ahead(_save3, !(
+          apply(:_AtxStart)  # end negation
+      ))) &&
+      ( _save4 = self.pos
+        look_ahead(_save4, !(
+          ( _save5 = self.pos  # sequence
+            apply(:_Line) &&
+            ( # choice
+              loop_range(1.., false) {
+                match_string("=")
+              } ||
+              loop_range(1.., false) {
+                match_string("-")
+              }
+              # end choice
+            ) &&
+            apply(:_Newline) ||
+            ( self.pos = _save5; nil )  # end sequence
+          )  # end negation
+      ))) &&
+      ( @result = (text(self, position, "\n")); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_NormalEndline
   end
 
   # TerminalEndline = Sp Newline Eof {text(self, position, "\n")}
   def _TerminalEndline
-
-    _save = self.pos
-    while true # sequence
-      _tmp = apply(:_Sp)
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = apply(:_Newline)
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = apply(:_Eof)
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin; text(self, position, "\n"); end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_TerminalEndline unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      apply(:_Sp) &&
+      apply(:_Newline) &&
+      apply(:_Eof) &&
+      ( @result = (text(self, position, "\n")); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_TerminalEndline
   end
 
   # LineBreak = "  " NormalEndline {linebreak(self, position)}
   def _LineBreak
-
-    _save = self.pos
-    while true # sequence
-      _tmp = match_string("  ")
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = apply(:_NormalEndline)
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin; linebreak(self, position); end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_LineBreak unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      match_string("  ") &&
+      apply(:_NormalEndline) &&
+      ( @result = (linebreak(self, position)); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_LineBreak
   end
 
   # Symbol = SpecialChar:c {text(self, position, c)}
   def _Symbol
-
-    _save = self.pos
-    while true # sequence
-      _tmp = apply(:_SpecialChar)
-      c = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin; text(self, position, c); end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_Symbol unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      apply(:_SpecialChar) &&
+      ( c = @result; true ) &&
+      ( @result = (text(self, position, c)); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_Symbol
   end
 
   # Emph = (EmphStar | EmphUl)
   def _Emph
-
-    _save = self.pos
-    while true # choice
-      _tmp = apply(:_EmphStar)
-      break if _tmp
-      self.pos = _save
-      _tmp = apply(:_EmphUl)
-      break if _tmp
-      self.pos = _save
-      break
-    end # end choice
-
-    set_failed_rule :_Emph unless _tmp
-    return _tmp
+    ( # choice
+      apply(:_EmphStar) ||
+      apply(:_EmphUl)
+      # end choice
+    ) or set_failed_rule :_Emph
   end
 
   # Whitespace = (Spacechar | Newline)
   def _Whitespace
-
-    _save = self.pos
-    while true # choice
-      _tmp = apply(:_Spacechar)
-      break if _tmp
-      self.pos = _save
-      _tmp = apply(:_Newline)
-      break if _tmp
-      self.pos = _save
-      break
-    end # end choice
-
-    set_failed_rule :_Whitespace unless _tmp
-    return _tmp
+    ( # choice
+      apply(:_Spacechar) ||
+      apply(:_Newline)
+      # end choice
+    ) or set_failed_rule :_Whitespace
   end
 
   # EmphStar = "*" !Whitespace (!"*" Inline:b { b } | StrongStar:b { b })+:c "*" {inline_element(self, position, :em, c)}
   def _EmphStar
-
-    _save = self.pos
-    while true # sequence
-      _tmp = match_string("*")
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save1 = self.pos
-      _tmp = apply(:_Whitespace)
-      _tmp = _tmp ? nil : true
-      self.pos = _save1
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save2 = self.pos
-      _ary = []
-
-      _save3 = self.pos
-      while true # choice
-
-        _save4 = self.pos
-        while true # sequence
-          _save5 = self.pos
-          _tmp = match_string("*")
-          _tmp = _tmp ? nil : true
-          self.pos = _save5
-          unless _tmp
-            self.pos = _save4
-            break
-          end
-          _tmp = apply(:_Inline)
-          b = @result
-          unless _tmp
-            self.pos = _save4
-            break
-          end
-          @result = begin;  b ; end
-          _tmp = true
-          unless _tmp
-            self.pos = _save4
-          end
-          break
-        end # end sequence
-
-        break if _tmp
-        self.pos = _save3
-
-        _save6 = self.pos
-        while true # sequence
-          _tmp = apply(:_StrongStar)
-          b = @result
-          unless _tmp
-            self.pos = _save6
-            break
-          end
-          @result = begin;  b ; end
-          _tmp = true
-          unless _tmp
-            self.pos = _save6
-          end
-          break
-        end # end sequence
-
-        break if _tmp
-        self.pos = _save3
-        break
-      end # end choice
-
-      if _tmp
-        _ary << @result
-        while true
-
-          _save7 = self.pos
-          while true # choice
-
-            _save8 = self.pos
-            while true # sequence
-              _save9 = self.pos
-              _tmp = match_string("*")
-              _tmp = _tmp ? nil : true
-              self.pos = _save9
-              unless _tmp
-                self.pos = _save8
-                break
-              end
-              _tmp = apply(:_Inline)
-              b = @result
-              unless _tmp
-                self.pos = _save8
-                break
-              end
-              @result = begin;  b ; end
-              _tmp = true
-              unless _tmp
-                self.pos = _save8
-              end
-              break
-            end # end sequence
-
-            break if _tmp
-            self.pos = _save7
-
-            _save10 = self.pos
-            while true # sequence
-              _tmp = apply(:_StrongStar)
-              b = @result
-              unless _tmp
-                self.pos = _save10
-                break
-              end
-              @result = begin;  b ; end
-              _tmp = true
-              unless _tmp
-                self.pos = _save10
-              end
-              break
-            end # end sequence
-
-            break if _tmp
-            self.pos = _save7
-            break
-          end # end choice
-
-          _ary << @result if _tmp
-          break unless _tmp
-        end
-        _tmp = true
-        @result = _ary
-      else
-        self.pos = _save2
-      end
-      c = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = match_string("*")
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin; inline_element(self, position, :em, c); end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_EmphStar unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      match_string("*") &&
+      ( _save1 = self.pos
+        look_ahead(_save1, !(
+          apply(:_Whitespace)  # end negation
+      ))) &&
+      loop_range(1.., true) {
+        ( # choice
+          ( _save2 = self.pos  # sequence
+            ( _save3 = self.pos
+              look_ahead(_save3, !(
+                match_string("*")  # end negation
+            ))) &&
+            apply(:_Inline) &&
+            ( b = @result; true ) &&
+            ( @result = (b); true ) ||
+            ( self.pos = _save2; nil )  # end sequence
+          ) ||
+          ( _save4 = self.pos  # sequence
+            apply(:_StrongStar) &&
+            ( b = @result; true ) &&
+            ( @result = (b); true ) ||
+            ( self.pos = _save4; nil )  # end sequence
+          )
+          # end choice
+        )
+      } &&
+      ( c = @result; true ) &&
+      match_string("*") &&
+      ( @result = (inline_element(self, position, :em, c)); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_EmphStar
   end
 
   # EmphUl = "_" !Whitespace (!"_" Inline:b { b } | StrongUl:b { b })+:c "_" {inline_element(self, position, :em, c)}
   def _EmphUl
-
-    _save = self.pos
-    while true # sequence
-      _tmp = match_string("_")
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save1 = self.pos
-      _tmp = apply(:_Whitespace)
-      _tmp = _tmp ? nil : true
-      self.pos = _save1
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save2 = self.pos
-      _ary = []
-
-      _save3 = self.pos
-      while true # choice
-
-        _save4 = self.pos
-        while true # sequence
-          _save5 = self.pos
-          _tmp = match_string("_")
-          _tmp = _tmp ? nil : true
-          self.pos = _save5
-          unless _tmp
-            self.pos = _save4
-            break
-          end
-          _tmp = apply(:_Inline)
-          b = @result
-          unless _tmp
-            self.pos = _save4
-            break
-          end
-          @result = begin;  b ; end
-          _tmp = true
-          unless _tmp
-            self.pos = _save4
-          end
-          break
-        end # end sequence
-
-        break if _tmp
-        self.pos = _save3
-
-        _save6 = self.pos
-        while true # sequence
-          _tmp = apply(:_StrongUl)
-          b = @result
-          unless _tmp
-            self.pos = _save6
-            break
-          end
-          @result = begin;  b ; end
-          _tmp = true
-          unless _tmp
-            self.pos = _save6
-          end
-          break
-        end # end sequence
-
-        break if _tmp
-        self.pos = _save3
-        break
-      end # end choice
-
-      if _tmp
-        _ary << @result
-        while true
-
-          _save7 = self.pos
-          while true # choice
-
-            _save8 = self.pos
-            while true # sequence
-              _save9 = self.pos
-              _tmp = match_string("_")
-              _tmp = _tmp ? nil : true
-              self.pos = _save9
-              unless _tmp
-                self.pos = _save8
-                break
-              end
-              _tmp = apply(:_Inline)
-              b = @result
-              unless _tmp
-                self.pos = _save8
-                break
-              end
-              @result = begin;  b ; end
-              _tmp = true
-              unless _tmp
-                self.pos = _save8
-              end
-              break
-            end # end sequence
-
-            break if _tmp
-            self.pos = _save7
-
-            _save10 = self.pos
-            while true # sequence
-              _tmp = apply(:_StrongUl)
-              b = @result
-              unless _tmp
-                self.pos = _save10
-                break
-              end
-              @result = begin;  b ; end
-              _tmp = true
-              unless _tmp
-                self.pos = _save10
-              end
-              break
-            end # end sequence
-
-            break if _tmp
-            self.pos = _save7
-            break
-          end # end choice
-
-          _ary << @result if _tmp
-          break unless _tmp
-        end
-        _tmp = true
-        @result = _ary
-      else
-        self.pos = _save2
-      end
-      c = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = match_string("_")
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin; inline_element(self, position, :em, c); end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_EmphUl unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      match_string("_") &&
+      ( _save1 = self.pos
+        look_ahead(_save1, !(
+          apply(:_Whitespace)  # end negation
+      ))) &&
+      loop_range(1.., true) {
+        ( # choice
+          ( _save2 = self.pos  # sequence
+            ( _save3 = self.pos
+              look_ahead(_save3, !(
+                match_string("_")  # end negation
+            ))) &&
+            apply(:_Inline) &&
+            ( b = @result; true ) &&
+            ( @result = (b); true ) ||
+            ( self.pos = _save2; nil )  # end sequence
+          ) ||
+          ( _save4 = self.pos  # sequence
+            apply(:_StrongUl) &&
+            ( b = @result; true ) &&
+            ( @result = (b); true ) ||
+            ( self.pos = _save4; nil )  # end sequence
+          )
+          # end choice
+        )
+      } &&
+      ( c = @result; true ) &&
+      match_string("_") &&
+      ( @result = (inline_element(self, position, :em, c)); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_EmphUl
   end
 
   # Strong = (StrongStar | StrongUl)
   def _Strong
-
-    _save = self.pos
-    while true # choice
-      _tmp = apply(:_StrongStar)
-      break if _tmp
-      self.pos = _save
-      _tmp = apply(:_StrongUl)
-      break if _tmp
-      self.pos = _save
-      break
-    end # end choice
-
-    set_failed_rule :_Strong unless _tmp
-    return _tmp
+    ( # choice
+      apply(:_StrongStar) ||
+      apply(:_StrongUl)
+      # end choice
+    ) or set_failed_rule :_Strong
   end
 
   # StrongStar = "**" !Whitespace (!"**" Inline:b { b })+:c "**" {inline_element(self, position, :strong, c)}
   def _StrongStar
-
-    _save = self.pos
-    while true # sequence
-      _tmp = match_string("**")
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save1 = self.pos
-      _tmp = apply(:_Whitespace)
-      _tmp = _tmp ? nil : true
-      self.pos = _save1
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save2 = self.pos
-      _ary = []
-
-      _save3 = self.pos
-      while true # sequence
-        _save4 = self.pos
-        _tmp = match_string("**")
-        _tmp = _tmp ? nil : true
-        self.pos = _save4
-        unless _tmp
-          self.pos = _save3
-          break
-        end
-        _tmp = apply(:_Inline)
-        b = @result
-        unless _tmp
-          self.pos = _save3
-          break
-        end
-        @result = begin;  b ; end
-        _tmp = true
-        unless _tmp
-          self.pos = _save3
-        end
-        break
-      end # end sequence
-
-      if _tmp
-        _ary << @result
-        while true
-
-          _save5 = self.pos
-          while true # sequence
-            _save6 = self.pos
-            _tmp = match_string("**")
-            _tmp = _tmp ? nil : true
-            self.pos = _save6
-            unless _tmp
-              self.pos = _save5
-              break
-            end
-            _tmp = apply(:_Inline)
-            b = @result
-            unless _tmp
-              self.pos = _save5
-              break
-            end
-            @result = begin;  b ; end
-            _tmp = true
-            unless _tmp
-              self.pos = _save5
-            end
-            break
-          end # end sequence
-
-          _ary << @result if _tmp
-          break unless _tmp
-        end
-        _tmp = true
-        @result = _ary
-      else
-        self.pos = _save2
-      end
-      c = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = match_string("**")
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin; inline_element(self, position, :strong, c); end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_StrongStar unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      match_string("**") &&
+      ( _save1 = self.pos
+        look_ahead(_save1, !(
+          apply(:_Whitespace)  # end negation
+      ))) &&
+      loop_range(1.., true) {
+        ( _save2 = self.pos  # sequence
+          ( _save3 = self.pos
+            look_ahead(_save3, !(
+              match_string("**")  # end negation
+          ))) &&
+          apply(:_Inline) &&
+          ( b = @result; true ) &&
+          ( @result = (b); true ) ||
+          ( self.pos = _save2; nil )  # end sequence
+        )
+      } &&
+      ( c = @result; true ) &&
+      match_string("**") &&
+      ( @result = (inline_element(self, position, :strong, c)); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_StrongStar
   end
 
   # StrongUl = "__" !Whitespace (!"__" Inline:b { b })+:c "__" {inline_element(self, position, :strong, c)}
   def _StrongUl
-
-    _save = self.pos
-    while true # sequence
-      _tmp = match_string("__")
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save1 = self.pos
-      _tmp = apply(:_Whitespace)
-      _tmp = _tmp ? nil : true
-      self.pos = _save1
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save2 = self.pos
-      _ary = []
-
-      _save3 = self.pos
-      while true # sequence
-        _save4 = self.pos
-        _tmp = match_string("__")
-        _tmp = _tmp ? nil : true
-        self.pos = _save4
-        unless _tmp
-          self.pos = _save3
-          break
-        end
-        _tmp = apply(:_Inline)
-        b = @result
-        unless _tmp
-          self.pos = _save3
-          break
-        end
-        @result = begin;  b ; end
-        _tmp = true
-        unless _tmp
-          self.pos = _save3
-        end
-        break
-      end # end sequence
-
-      if _tmp
-        _ary << @result
-        while true
-
-          _save5 = self.pos
-          while true # sequence
-            _save6 = self.pos
-            _tmp = match_string("__")
-            _tmp = _tmp ? nil : true
-            self.pos = _save6
-            unless _tmp
-              self.pos = _save5
-              break
-            end
-            _tmp = apply(:_Inline)
-            b = @result
-            unless _tmp
-              self.pos = _save5
-              break
-            end
-            @result = begin;  b ; end
-            _tmp = true
-            unless _tmp
-              self.pos = _save5
-            end
-            break
-          end # end sequence
-
-          _ary << @result if _tmp
-          break unless _tmp
-        end
-        _tmp = true
-        @result = _ary
-      else
-        self.pos = _save2
-      end
-      c = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = match_string("__")
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin; inline_element(self, position, :strong, c); end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_StrongUl unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      match_string("__") &&
+      ( _save1 = self.pos
+        look_ahead(_save1, !(
+          apply(:_Whitespace)  # end negation
+      ))) &&
+      loop_range(1.., true) {
+        ( _save2 = self.pos  # sequence
+          ( _save3 = self.pos
+            look_ahead(_save3, !(
+              match_string("__")  # end negation
+          ))) &&
+          apply(:_Inline) &&
+          ( b = @result; true ) &&
+          ( @result = (b); true ) ||
+          ( self.pos = _save2; nil )  # end sequence
+        )
+      } &&
+      ( c = @result; true ) &&
+      match_string("__") &&
+      ( @result = (inline_element(self, position, :strong, c)); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_StrongUl
   end
 
   # Ticks1 = < /`/ > !"`" { text }
   def _Ticks1
-
-    _save = self.pos
-    while true # sequence
-      _text_start = self.pos
-      _tmp = scan(/\G(?-mix:`)/)
-      if _tmp
-        text = get_text(_text_start)
-      end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save1 = self.pos
-      _tmp = match_string("`")
-      _tmp = _tmp ? nil : true
-      self.pos = _save1
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  text ; end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_Ticks1 unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      ( _text_start = self.pos
+        scan(/\G(?-mix:`)/) &&
+        ( text = get_text(_text_start); true )
+      ) &&
+      ( _save1 = self.pos
+        look_ahead(_save1, !(
+          match_string("`")  # end negation
+      ))) &&
+      ( @result = (text); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_Ticks1
   end
 
   # Ticks2 = < /``/ > !"`" { text }
   def _Ticks2
-
-    _save = self.pos
-    while true # sequence
-      _text_start = self.pos
-      _tmp = scan(/\G(?-mix:``)/)
-      if _tmp
-        text = get_text(_text_start)
-      end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save1 = self.pos
-      _tmp = match_string("`")
-      _tmp = _tmp ? nil : true
-      self.pos = _save1
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  text ; end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_Ticks2 unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      ( _text_start = self.pos
+        scan(/\G(?-mix:``)/) &&
+        ( text = get_text(_text_start); true )
+      ) &&
+      ( _save1 = self.pos
+        look_ahead(_save1, !(
+          match_string("`")  # end negation
+      ))) &&
+      ( @result = (text); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_Ticks2
   end
 
   # Code = (Ticks1 Sp (!"`" Nonspacechar)+:c Sp Ticks1 {text(self, position, c.join(""))} | Ticks2 Sp (!"``" Nonspacechar)+:c Sp Ticks2 {text(self, position, c.join(""))}):cc {inline_element(self, position, :code, [cc])}
   def _Code
-
-    _save = self.pos
-    while true # sequence
-
-      _save1 = self.pos
-      while true # choice
-
-        _save2 = self.pos
-        while true # sequence
-          _tmp = apply(:_Ticks1)
-          unless _tmp
-            self.pos = _save2
-            break
-          end
-          _tmp = apply(:_Sp)
-          unless _tmp
-            self.pos = _save2
-            break
-          end
-          _save3 = self.pos
-          _ary = []
-
-          _save4 = self.pos
-          while true # sequence
-            _save5 = self.pos
-            _tmp = match_string("`")
-            _tmp = _tmp ? nil : true
-            self.pos = _save5
-            unless _tmp
-              self.pos = _save4
-              break
-            end
-            _tmp = apply(:_Nonspacechar)
-            unless _tmp
-              self.pos = _save4
-            end
-            break
-          end # end sequence
-
-          if _tmp
-            _ary << @result
-            while true
-
-              _save6 = self.pos
-              while true # sequence
-                _save7 = self.pos
-                _tmp = match_string("`")
-                _tmp = _tmp ? nil : true
-                self.pos = _save7
-                unless _tmp
-                  self.pos = _save6
-                  break
-                end
-                _tmp = apply(:_Nonspacechar)
-                unless _tmp
-                  self.pos = _save6
-                end
-                break
-              end # end sequence
-
-              _ary << @result if _tmp
-              break unless _tmp
-            end
-            _tmp = true
-            @result = _ary
-          else
-            self.pos = _save3
-          end
-          c = @result
-          unless _tmp
-            self.pos = _save2
-            break
-          end
-          _tmp = apply(:_Sp)
-          unless _tmp
-            self.pos = _save2
-            break
-          end
-          _tmp = apply(:_Ticks1)
-          unless _tmp
-            self.pos = _save2
-            break
-          end
-          @result = begin; text(self, position, c.join("")); end
-          _tmp = true
-          unless _tmp
-            self.pos = _save2
-          end
-          break
-        end # end sequence
-
-        break if _tmp
-        self.pos = _save1
-
-        _save8 = self.pos
-        while true # sequence
-          _tmp = apply(:_Ticks2)
-          unless _tmp
-            self.pos = _save8
-            break
-          end
-          _tmp = apply(:_Sp)
-          unless _tmp
-            self.pos = _save8
-            break
-          end
-          _save9 = self.pos
-          _ary = []
-
-          _save10 = self.pos
-          while true # sequence
-            _save11 = self.pos
-            _tmp = match_string("``")
-            _tmp = _tmp ? nil : true
-            self.pos = _save11
-            unless _tmp
-              self.pos = _save10
-              break
-            end
-            _tmp = apply(:_Nonspacechar)
-            unless _tmp
-              self.pos = _save10
-            end
-            break
-          end # end sequence
-
-          if _tmp
-            _ary << @result
-            while true
-
-              _save12 = self.pos
-              while true # sequence
-                _save13 = self.pos
-                _tmp = match_string("``")
-                _tmp = _tmp ? nil : true
-                self.pos = _save13
-                unless _tmp
-                  self.pos = _save12
-                  break
-                end
-                _tmp = apply(:_Nonspacechar)
-                unless _tmp
-                  self.pos = _save12
-                end
-                break
-              end # end sequence
-
-              _ary << @result if _tmp
-              break unless _tmp
-            end
-            _tmp = true
-            @result = _ary
-          else
-            self.pos = _save9
-          end
-          c = @result
-          unless _tmp
-            self.pos = _save8
-            break
-          end
-          _tmp = apply(:_Sp)
-          unless _tmp
-            self.pos = _save8
-            break
-          end
-          _tmp = apply(:_Ticks2)
-          unless _tmp
-            self.pos = _save8
-            break
-          end
-          @result = begin; text(self, position, c.join("")); end
-          _tmp = true
-          unless _tmp
-            self.pos = _save8
-          end
-          break
-        end # end sequence
-
-        break if _tmp
-        self.pos = _save1
-        break
-      end # end choice
-
-      cc = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin; inline_element(self, position, :code, [cc]); end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_Code unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      ( # choice
+        ( _save1 = self.pos  # sequence
+          apply(:_Ticks1) &&
+          apply(:_Sp) &&
+          loop_range(1.., true) {
+            ( _save2 = self.pos  # sequence
+              ( _save3 = self.pos
+                look_ahead(_save3, !(
+                  match_string("`")  # end negation
+              ))) &&
+              apply(:_Nonspacechar) ||
+              ( self.pos = _save2; nil )  # end sequence
+            )
+          } &&
+          ( c = @result; true ) &&
+          apply(:_Sp) &&
+          apply(:_Ticks1) &&
+          ( @result = (text(self, position, c.join(""))); true ) ||
+          ( self.pos = _save1; nil )  # end sequence
+        ) ||
+        ( _save4 = self.pos  # sequence
+          apply(:_Ticks2) &&
+          apply(:_Sp) &&
+          loop_range(1.., true) {
+            ( _save5 = self.pos  # sequence
+              ( _save6 = self.pos
+                look_ahead(_save6, !(
+                  match_string("``")  # end negation
+              ))) &&
+              apply(:_Nonspacechar) ||
+              ( self.pos = _save5; nil )  # end sequence
+            )
+          } &&
+          ( c = @result; true ) &&
+          apply(:_Sp) &&
+          apply(:_Ticks2) &&
+          ( @result = (text(self, position, c.join(""))); true ) ||
+          ( self.pos = _save4; nil )  # end sequence
+        )
+        # end choice
+      ) &&
+      ( cc = @result; true ) &&
+      ( @result = (inline_element(self, position, :code, [cc])); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_Code
   end
 
   # BlankLine = Sp Newline
   def _BlankLine
-
-    _save = self.pos
-    while true # sequence
-      _tmp = apply(:_Sp)
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = apply(:_Newline)
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_BlankLine unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      apply(:_Sp) &&
+      apply(:_Newline) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_BlankLine
   end
 
   # Quoted = ("\"" (!"\"" .)* "\"" | "'" (!"'" .)* "'")
   def _Quoted
-
-    _save = self.pos
-    while true # choice
-
-      _save1 = self.pos
-      while true # sequence
-        _tmp = match_string("\"")
-        unless _tmp
-          self.pos = _save1
-          break
-        end
-        while true
-
-          _save3 = self.pos
-          while true # sequence
-            _save4 = self.pos
-            _tmp = match_string("\"")
-            _tmp = _tmp ? nil : true
-            self.pos = _save4
-            unless _tmp
-              self.pos = _save3
-              break
-            end
-            _tmp = get_byte
-            unless _tmp
-              self.pos = _save3
-            end
-            break
-          end # end sequence
-
-          break unless _tmp
-        end
-        _tmp = true
-        unless _tmp
-          self.pos = _save1
-          break
-        end
-        _tmp = match_string("\"")
-        unless _tmp
-          self.pos = _save1
-        end
-        break
-      end # end sequence
-
-      break if _tmp
-      self.pos = _save
-
-      _save5 = self.pos
-      while true # sequence
-        _tmp = match_string("'")
-        unless _tmp
-          self.pos = _save5
-          break
-        end
-        while true
-
-          _save7 = self.pos
-          while true # sequence
-            _save8 = self.pos
-            _tmp = match_string("'")
-            _tmp = _tmp ? nil : true
-            self.pos = _save8
-            unless _tmp
-              self.pos = _save7
-              break
-            end
-            _tmp = get_byte
-            unless _tmp
-              self.pos = _save7
-            end
-            break
-          end # end sequence
-
-          break unless _tmp
-        end
-        _tmp = true
-        unless _tmp
-          self.pos = _save5
-          break
-        end
-        _tmp = match_string("'")
-        unless _tmp
-          self.pos = _save5
-        end
-        break
-      end # end sequence
-
-      break if _tmp
-      self.pos = _save
-      break
-    end # end choice
-
-    set_failed_rule :_Quoted unless _tmp
-    return _tmp
+    ( # choice
+      ( _save = self.pos  # sequence
+        match_string("\"") &&
+        while true  # kleene
+          ( _save1 = self.pos  # sequence
+            ( _save2 = self.pos
+              look_ahead(_save2, !(
+                match_string("\"")  # end negation
+            ))) &&
+            get_byte ||
+            ( self.pos = _save1; nil )  # end sequence
+          ) || (break true) # end kleene
+        end &&
+        match_string("\"") ||
+        ( self.pos = _save; nil )  # end sequence
+      ) ||
+      ( _save3 = self.pos  # sequence
+        match_string("'") &&
+        while true  # kleene
+          ( _save4 = self.pos  # sequence
+            ( _save5 = self.pos
+              look_ahead(_save5, !(
+                match_string("'")  # end negation
+            ))) &&
+            get_byte ||
+            ( self.pos = _save4; nil )  # end sequence
+          ) || (break true) # end kleene
+        end &&
+        match_string("'") ||
+        ( self.pos = _save3; nil )  # end sequence
+      )
+      # end choice
+    ) or set_failed_rule :_Quoted
   end
 
   # Eof = !.
   def _Eof
-    _save = self.pos
-    _tmp = get_byte
-    _tmp = _tmp ? nil : true
-    self.pos = _save
-    set_failed_rule :_Eof unless _tmp
-    return _tmp
+    ( _save = self.pos
+      look_ahead(_save, !(
+        get_byte  # end negation
+    ))) or set_failed_rule :_Eof
   end
 
   # Spacechar = < / |\t/ > { text }
   def _Spacechar
-
-    _save = self.pos
-    while true # sequence
-      _text_start = self.pos
-      _tmp = scan(/\G(?-mix: |\t)/)
-      if _tmp
-        text = get_text(_text_start)
-      end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  text ; end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_Spacechar unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      ( _text_start = self.pos
+        scan(/\G(?-mix: |\t)/) &&
+        ( text = get_text(_text_start); true )
+      ) &&
+      ( @result = (text); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_Spacechar
   end
 
   # Nonspacechar = !Spacechar !Newline < . > { text }
   def _Nonspacechar
-
-    _save = self.pos
-    while true # sequence
-      _save1 = self.pos
-      _tmp = apply(:_Spacechar)
-      _tmp = _tmp ? nil : true
-      self.pos = _save1
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save2 = self.pos
-      _tmp = apply(:_Newline)
-      _tmp = _tmp ? nil : true
-      self.pos = _save2
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _text_start = self.pos
-      _tmp = get_byte
-      if _tmp
-        text = get_text(_text_start)
-      end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  text ; end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_Nonspacechar unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      ( _save1 = self.pos
+        look_ahead(_save1, !(
+          apply(:_Spacechar)  # end negation
+      ))) &&
+      ( _save2 = self.pos
+        look_ahead(_save2, !(
+          apply(:_Newline)  # end negation
+      ))) &&
+      ( _text_start = self.pos
+        get_byte &&
+        ( text = get_text(_text_start); true )
+      ) &&
+      ( @result = (text); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_Nonspacechar
   end
 
   # Newline = ("\n" | "\r" "\n"?)
   def _Newline
-
-    _save = self.pos
-    while true # choice
-      _tmp = match_string("\n")
-      break if _tmp
-      self.pos = _save
-
-      _save1 = self.pos
-      while true # sequence
-        _tmp = match_string("\r")
-        unless _tmp
-          self.pos = _save1
-          break
-        end
-        _save2 = self.pos
-        _tmp = match_string("\n")
-        unless _tmp
-          _tmp = true
-          self.pos = _save2
-        end
-        unless _tmp
-          self.pos = _save1
-        end
-        break
-      end # end sequence
-
-      break if _tmp
-      self.pos = _save
-      break
-    end # end choice
-
-    set_failed_rule :_Newline unless _tmp
-    return _tmp
+    ( # choice
+      match_string("\n") ||
+      ( _save = self.pos  # sequence
+        match_string("\r") &&
+        ( _save1 = self.pos  # optional
+          match_string("\n") ||
+          ( self.pos = _save1; true )  # end optional
+        ) ||
+        ( self.pos = _save; nil )  # end sequence
+      )
+      # end choice
+    ) or set_failed_rule :_Newline
   end
 
   # Sp = Spacechar*
   def _Sp
-    while true
-      _tmp = apply(:_Spacechar)
-      break unless _tmp
-    end
-    _tmp = true
-    set_failed_rule :_Sp unless _tmp
-    return _tmp
+    while true  # kleene
+      apply(:_Spacechar) || (break true) # end kleene
+    end or set_failed_rule :_Sp
   end
 
   # Spnl = Sp (Newline Sp)?
   def _Spnl
-
-    _save = self.pos
-    while true # sequence
-      _tmp = apply(:_Sp)
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save1 = self.pos
-
-      _save2 = self.pos
-      while true # sequence
-        _tmp = apply(:_Newline)
-        unless _tmp
-          self.pos = _save2
-          break
-        end
-        _tmp = apply(:_Sp)
-        unless _tmp
-          self.pos = _save2
-        end
-        break
-      end # end sequence
-
-      unless _tmp
-        _tmp = true
-        self.pos = _save1
-      end
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_Spnl unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      apply(:_Sp) &&
+      ( _save1 = self.pos  # optional
+        ( _save2 = self.pos  # sequence
+          apply(:_Newline) &&
+          apply(:_Sp) ||
+          ( self.pos = _save2; nil )  # end sequence
+        ) ||
+        ( self.pos = _save1; true )  # end optional
+      ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_Spnl
   end
 
   # SpecialChar = < /[~*_`&\[\]()<!#\\'"]/ > { text }
   def _SpecialChar
-
-    _save = self.pos
-    while true # sequence
-      _text_start = self.pos
-      _tmp = scan(/\G(?-mix:[~*_`&\[\]()<!#\\'"])/)
-      if _tmp
-        text = get_text(_text_start)
-      end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  text ; end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_SpecialChar unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      ( _text_start = self.pos
+        scan(/\G(?-mix:[~*_`&\[\]()<!#\\'"])/) &&
+        ( text = get_text(_text_start); true )
+      ) &&
+      ( @result = (text); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_SpecialChar
   end
 
   # NormalChar = !(SpecialChar | Spacechar | Newline) < . > { text }
   def _NormalChar
-
-    _save = self.pos
-    while true # sequence
-      _save1 = self.pos
-
-      _save2 = self.pos
-      while true # choice
-        _tmp = apply(:_SpecialChar)
-        break if _tmp
-        self.pos = _save2
-        _tmp = apply(:_Spacechar)
-        break if _tmp
-        self.pos = _save2
-        _tmp = apply(:_Newline)
-        break if _tmp
-        self.pos = _save2
-        break
-      end # end choice
-
-      _tmp = _tmp ? nil : true
-      self.pos = _save1
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _text_start = self.pos
-      _tmp = get_byte
-      if _tmp
-        text = get_text(_text_start)
-      end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  text ; end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_NormalChar unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      ( _save1 = self.pos
+        look_ahead(_save1, !(
+          ( # choice
+            apply(:_SpecialChar) ||
+            apply(:_Spacechar) ||
+            apply(:_Newline)
+            # end choice
+          )  # end negation
+      ))) &&
+      ( _text_start = self.pos
+        get_byte &&
+        ( text = get_text(_text_start); true )
+      ) &&
+      ( @result = (text); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_NormalChar
   end
 
   # AlphanumericAscii = < /[A-Za-z0-9]/ > { text }
   def _AlphanumericAscii
-
-    _save = self.pos
-    while true # sequence
-      _text_start = self.pos
-      _tmp = scan(/\G(?-mix:[A-Za-z0-9])/)
-      if _tmp
-        text = get_text(_text_start)
-      end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  text ; end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_AlphanumericAscii unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      ( _text_start = self.pos
+        scan(/\G(?-mix:[A-Za-z0-9])/) &&
+        ( text = get_text(_text_start); true )
+      ) &&
+      ( @result = (text); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_AlphanumericAscii
   end
 
   # Digit = < /[0-9]/ > { text }
   def _Digit
-
-    _save = self.pos
-    while true # sequence
-      _text_start = self.pos
-      _tmp = scan(/\G(?-mix:[0-9])/)
-      if _tmp
-        text = get_text(_text_start)
-      end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  text ; end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_Digit unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      ( _text_start = self.pos
+        scan(/\G(?-mix:[0-9])/) &&
+        ( text = get_text(_text_start); true )
+      ) &&
+      ( @result = (text); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_Digit
   end
 
   # NonindentSpace = < /   |  | |/ > { text }
   def _NonindentSpace
-
-    _save = self.pos
-    while true # sequence
-      _text_start = self.pos
-      _tmp = scan(/\G(?-mix:   |  | |)/)
-      if _tmp
-        text = get_text(_text_start)
-      end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  text ; end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_NonindentSpace unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      ( _text_start = self.pos
+        scan(/\G(?-mix:   |  | |)/) &&
+        ( text = get_text(_text_start); true )
+      ) &&
+      ( @result = (text); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_NonindentSpace
   end
 
   # Indent = < /\t|    / > { text }
   def _Indent
-
-    _save = self.pos
-    while true # sequence
-      _text_start = self.pos
-      _tmp = scan(/\G(?-mix:\t|    )/)
-      if _tmp
-        text = get_text(_text_start)
-      end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  text ; end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_Indent unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      ( _text_start = self.pos
+        scan(/\G(?-mix:\t|    )/) &&
+        ( text = get_text(_text_start); true )
+      ) &&
+      ( @result = (text); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_Indent
   end
 
   # IndentedLine = Indent Line:c { c }
   def _IndentedLine
-
-    _save = self.pos
-    while true # sequence
-      _tmp = apply(:_Indent)
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = apply(:_Line)
-      c = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  c ; end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_IndentedLine unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      apply(:_Indent) &&
+      apply(:_Line) &&
+      ( c = @result; true ) &&
+      ( @result = (c); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_IndentedLine
   end
 
   # OptionallyIndentedLine = Indent? Line
   def _OptionallyIndentedLine
-
-    _save = self.pos
-    while true # sequence
-      _save1 = self.pos
-      _tmp = apply(:_Indent)
-      unless _tmp
-        _tmp = true
-        self.pos = _save1
-      end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = apply(:_Line)
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_OptionallyIndentedLine unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      ( _save1 = self.pos  # optional
+        apply(:_Indent) ||
+        ( self.pos = _save1; true )  # end optional
+      ) &&
+      apply(:_Line) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_OptionallyIndentedLine
   end
 
   # Line = RawLine:c { c }
   def _Line
-
-    _save = self.pos
-    while true # sequence
-      _tmp = apply(:_RawLine)
-      c = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  c ; end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_Line unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      apply(:_RawLine) &&
+      ( c = @result; true ) &&
+      ( @result = (c); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_Line
   end
 
   # RawLine = (< /[^\r\n]*/ > Newline { text } | < /.+/ > Eof { text }):c {text(self, position, c)}
   def _RawLine
-
-    _save = self.pos
-    while true # sequence
-
-      _save1 = self.pos
-      while true # choice
-
-        _save2 = self.pos
-        while true # sequence
-          _text_start = self.pos
-          _tmp = scan(/\G(?-mix:[^\r\n]*)/)
-          if _tmp
-            text = get_text(_text_start)
-          end
-          unless _tmp
-            self.pos = _save2
-            break
-          end
-          _tmp = apply(:_Newline)
-          unless _tmp
-            self.pos = _save2
-            break
-          end
-          @result = begin;  text ; end
-          _tmp = true
-          unless _tmp
-            self.pos = _save2
-          end
-          break
-        end # end sequence
-
-        break if _tmp
-        self.pos = _save1
-
-        _save3 = self.pos
-        while true # sequence
-          _text_start = self.pos
-          _tmp = scan(/\G(?-mix:.+)/)
-          if _tmp
-            text = get_text(_text_start)
-          end
-          unless _tmp
-            self.pos = _save3
-            break
-          end
-          _tmp = apply(:_Eof)
-          unless _tmp
-            self.pos = _save3
-            break
-          end
-          @result = begin;  text ; end
-          _tmp = true
-          unless _tmp
-            self.pos = _save3
-          end
-          break
-        end # end sequence
-
-        break if _tmp
-        self.pos = _save1
-        break
-      end # end choice
-
-      c = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin; text(self, position, c); end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_RawLine unless _tmp
-    return _tmp
+    ( _save = self.pos  # sequence
+      ( # choice
+        ( _save1 = self.pos  # sequence
+          ( _text_start = self.pos
+            scan(/\G(?-mix:[^\r\n]*)/) &&
+            ( text = get_text(_text_start); true )
+          ) &&
+          apply(:_Newline) &&
+          ( @result = (text); true ) ||
+          ( self.pos = _save1; nil )  # end sequence
+        ) ||
+        ( _save2 = self.pos  # sequence
+          ( _text_start = self.pos
+            scan(/\G(?-mix:.+)/) &&
+            ( text = get_text(_text_start); true )
+          ) &&
+          apply(:_Eof) &&
+          ( @result = (text); true ) ||
+          ( self.pos = _save2; nil )  # end sequence
+        )
+        # end choice
+      ) &&
+      ( c = @result; true ) &&
+      ( @result = (text(self, position, c)); true ) ||
+      ( self.pos = _save; nil )  # end sequence
+    ) or set_failed_rule :_RawLine
   end
 
   Rules = {}

--- a/lib/kpeg/compiled_parser.rb
+++ b/lib/kpeg/compiled_parser.rb
@@ -173,9 +173,19 @@ module KPeg
       end
     end
 
+    def sequence(pos, action)
+      @pos = pos  unless action
+      action ? true : nil
+    end
+
     def look_ahead(pos, action)
       @pos = pos
       action ? true : nil
+    end
+
+    def look_negation(pos, action)
+      @pos = pos
+      action ? nil : true
     end
 
     def loop_range(range, store)

--- a/lib/kpeg/compiled_parser.rb
+++ b/lib/kpeg/compiled_parser.rb
@@ -127,6 +127,7 @@ module KPeg
         @failed_rule = name
         @failing_rule_offset = @pos
       end
+      nil
     end
 
     attr_reader :failed_rule
@@ -169,6 +170,32 @@ module KPeg
         s = @string[@pos]
         @pos += 1
         s
+      end
+    end
+
+    def look_ahead(pos, action)
+      @pos = pos
+      action ? true : nil
+    end
+
+    def loop_range(range, store)
+      _ary = [] if store
+      max = range.end && range.max
+      count = 0
+      save = @pos
+      while (!max || count < max) && yield
+        count += 1
+        if store
+          _ary << @result
+          @result = nil
+        end
+      end
+      if range.include?(count)
+        @result = _ary if store
+        true
+      else
+        @pos = save
+        nil
       end
     end
 

--- a/lib/kpeg/format_parser.rb
+++ b/lib/kpeg/format_parser.rb
@@ -231,9 +231,19 @@ class KPeg::FormatParser
       end
     end
 
+    def sequence(pos, action)
+      @pos = pos  unless action
+      action ? true : nil
+    end
+
     def look_ahead(pos, action)
       @pos = pos
       action ? true : nil
+    end
+
+    def look_negation(pos, action)
+      @pos = pos
+      action ? nil : true
     end
 
     def loop_range(range, store)
@@ -444,38 +454,32 @@ class KPeg::FormatParser
 
   # eof_comment = "#" (!eof .)*
   def _eof_comment
-    ( _save = self.pos  # sequence
+    sequence(self.pos,  # sequence
       match_string("#") &&
       while true  # kleene
-        ( _save1 = self.pos  # sequence
-          ( _save2 = self.pos
-            look_ahead(_save2, !(
-              apply(:_eof)  # end negation
-          ))) &&
-          get_byte ||
-          ( self.pos = _save1; nil )  # end sequence
+        sequence(self.pos,  # sequence
+          look_negation(self.pos,
+            apply(:_eof)  # end negation
+          ) &&
+          get_byte  # end sequence
         ) || (break true) # end kleene
-      end ||
-      ( self.pos = _save; nil )  # end sequence
+      end  # end sequence
     ) or set_failed_rule :_eof_comment
   end
 
   # comment = "#" (!eol .)* eol
   def _comment
-    ( _save = self.pos  # sequence
+    sequence(self.pos,  # sequence
       match_string("#") &&
       while true  # kleene
-        ( _save1 = self.pos  # sequence
-          ( _save2 = self.pos
-            look_ahead(_save2, !(
-              apply(:_eol)  # end negation
-          ))) &&
-          get_byte ||
-          ( self.pos = _save1; nil )  # end sequence
+        sequence(self.pos,  # sequence
+          look_negation(self.pos,
+            apply(:_eol)  # end negation
+          ) &&
+          get_byte  # end sequence
         ) || (break true) # end kleene
       end &&
-      apply(:_eol) ||
-      ( self.pos = _save; nil )  # end sequence
+      apply(:_eol)  # end sequence
     ) or set_failed_rule :_comment
   end
 
@@ -507,7 +511,7 @@ class KPeg::FormatParser
 
   # var = < ("-" | /[a-z][\w-]*/i) > { text }
   def _var
-    ( _save = self.pos  # sequence
+    sequence(self.pos,  # sequence
       ( _text_start = self.pos
         ( # choice
           match_string("-") ||
@@ -516,89 +520,75 @@ class KPeg::FormatParser
         ) &&
         ( text = get_text(_text_start); true )
       ) &&
-      ( @result = (text); true ) ||
-      ( self.pos = _save; nil )  # end sequence
+      ( @result = (text); true )  # end sequence
     ) or set_failed_rule :_var
   end
 
   # method = < /[a-z_]\w*/i > { text }
   def _method
-    ( _save = self.pos  # sequence
+    sequence(self.pos,  # sequence
       ( _text_start = self.pos
         scan(/\G(?i-mx:[a-z_]\w*)/) &&
         ( text = get_text(_text_start); true )
       ) &&
-      ( @result = (text); true ) ||
-      ( self.pos = _save; nil )  # end sequence
+      ( @result = (text); true )  # end sequence
     ) or set_failed_rule :_method
   end
 
   # dbl_escapes = ("n" { "\n" } | "s" { " " } | "r" { "\r" } | "t" { "\t" } | "v" { "\v" } | "f" { "\f" } | "b" { "\b" } | "a" { "\a" } | "e" { "\e" } | "\\" { "\\" } | "\"" { "\"" } | num_escapes | < . > { text })
   def _dbl_escapes
     ( # choice
-      ( _save = self.pos  # sequence
+      sequence(self.pos,  # sequence
         match_string("n") &&
-        ( @result = ("\n"); true ) ||
-        ( self.pos = _save; nil )  # end sequence
+        ( @result = ("\n"); true )  # end sequence
       ) ||
-      ( _save1 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         match_string("s") &&
-        ( @result = (" "); true ) ||
-        ( self.pos = _save1; nil )  # end sequence
+        ( @result = (" "); true )  # end sequence
       ) ||
-      ( _save2 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         match_string("r") &&
-        ( @result = ("\r"); true ) ||
-        ( self.pos = _save2; nil )  # end sequence
+        ( @result = ("\r"); true )  # end sequence
       ) ||
-      ( _save3 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         match_string("t") &&
-        ( @result = ("\t"); true ) ||
-        ( self.pos = _save3; nil )  # end sequence
+        ( @result = ("\t"); true )  # end sequence
       ) ||
-      ( _save4 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         match_string("v") &&
-        ( @result = ("\v"); true ) ||
-        ( self.pos = _save4; nil )  # end sequence
+        ( @result = ("\v"); true )  # end sequence
       ) ||
-      ( _save5 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         match_string("f") &&
-        ( @result = ("\f"); true ) ||
-        ( self.pos = _save5; nil )  # end sequence
+        ( @result = ("\f"); true )  # end sequence
       ) ||
-      ( _save6 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         match_string("b") &&
-        ( @result = ("\b"); true ) ||
-        ( self.pos = _save6; nil )  # end sequence
+        ( @result = ("\b"); true )  # end sequence
       ) ||
-      ( _save7 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         match_string("a") &&
-        ( @result = ("\a"); true ) ||
-        ( self.pos = _save7; nil )  # end sequence
+        ( @result = ("\a"); true )  # end sequence
       ) ||
-      ( _save8 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         match_string("e") &&
-        ( @result = ("\e"); true ) ||
-        ( self.pos = _save8; nil )  # end sequence
+        ( @result = ("\e"); true )  # end sequence
       ) ||
-      ( _save9 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         match_string("\\") &&
-        ( @result = ("\\"); true ) ||
-        ( self.pos = _save9; nil )  # end sequence
+        ( @result = ("\\"); true )  # end sequence
       ) ||
-      ( _save10 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         match_string("\"") &&
-        ( @result = ("\""); true ) ||
-        ( self.pos = _save10; nil )  # end sequence
+        ( @result = ("\""); true )  # end sequence
       ) ||
       apply(:_num_escapes) ||
-      ( _save11 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         ( _text_start = self.pos
           get_byte &&
           ( text = get_text(_text_start); true )
         ) &&
-        ( @result = (text); true ) ||
-        ( self.pos = _save11; nil )  # end sequence
+        ( @result = (text); true )  # end sequence
       )
       # end choice
     ) or set_failed_rule :_dbl_escapes
@@ -607,22 +597,20 @@ class KPeg::FormatParser
   # num_escapes = (< /[0-7]{1,3}/ > { [text.to_i(8)].pack("U") } | "x" < /[a-f\d]{2}/i > { [text.to_i(16)].pack("U") })
   def _num_escapes
     ( # choice
-      ( _save = self.pos  # sequence
+      sequence(self.pos,  # sequence
         ( _text_start = self.pos
           scan(/\G(?-mix:[0-7]{1,3})/) &&
           ( text = get_text(_text_start); true )
         ) &&
-        ( @result = ([text.to_i(8)].pack("U")); true ) ||
-        ( self.pos = _save; nil )  # end sequence
+        ( @result = ([text.to_i(8)].pack("U")); true )  # end sequence
       ) ||
-      ( _save1 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         match_string("x") &&
         ( _text_start = self.pos
           scan(/\G(?i-mx:[a-f\d]{2})/) &&
           ( text = get_text(_text_start); true )
         ) &&
-        ( @result = ([text.to_i(16)].pack("U")); true ) ||
-        ( self.pos = _save1; nil )  # end sequence
+        ( @result = ([text.to_i(16)].pack("U")); true )  # end sequence
       )
       # end choice
     ) or set_failed_rule :_num_escapes
@@ -630,72 +618,66 @@ class KPeg::FormatParser
 
   # dbl_seq = < /[^\\"]+/ > { text }
   def _dbl_seq
-    ( _save = self.pos  # sequence
+    sequence(self.pos,  # sequence
       ( _text_start = self.pos
         scan(/\G(?-mix:[^\\"]+)/) &&
         ( text = get_text(_text_start); true )
       ) &&
-      ( @result = (text); true ) ||
-      ( self.pos = _save; nil )  # end sequence
+      ( @result = (text); true )  # end sequence
     ) or set_failed_rule :_dbl_seq
   end
 
   # dbl_not_quote = ("\\" dbl_escapes | dbl_seq)*:ary { Array(ary) }
   def _dbl_not_quote
-    ( _save = self.pos  # sequence
+    sequence(self.pos,  # sequence
       loop_range(0.., true) {
         ( # choice
-          ( _save1 = self.pos  # sequence
+          sequence(self.pos,  # sequence
             match_string("\\") &&
-            apply(:_dbl_escapes) ||
-            ( self.pos = _save1; nil )  # end sequence
+            apply(:_dbl_escapes)  # end sequence
           ) ||
           apply(:_dbl_seq)
           # end choice
         )
       } &&
       ( ary = @result; true ) &&
-      ( @result = (Array(ary)); true ) ||
-      ( self.pos = _save; nil )  # end sequence
+      ( @result = (Array(ary)); true )  # end sequence
     ) or set_failed_rule :_dbl_not_quote
   end
 
   # dbl_string = "\"" dbl_not_quote:s "\"" { @g.str(s.join) }
   def _dbl_string
-    ( _save = self.pos  # sequence
+    sequence(self.pos,  # sequence
       match_string("\"") &&
       apply(:_dbl_not_quote) &&
       ( s = @result; true ) &&
       match_string("\"") &&
-      ( @result = (@g.str(s.join)); true ) ||
-      ( self.pos = _save; nil )  # end sequence
+      ( @result = (@g.str(s.join)); true )  # end sequence
     ) or set_failed_rule :_dbl_string
   end
 
   # sgl_escape_quote = "\\'" { "'" }
   def _sgl_escape_quote
-    ( _save = self.pos  # sequence
+    sequence(self.pos,  # sequence
       match_string("\\'") &&
-      ( @result = ("'"); true ) ||
-      ( self.pos = _save; nil )  # end sequence
+      ( @result = ("'"); true )  # end sequence
     ) or set_failed_rule :_sgl_escape_quote
   end
 
   # sgl_seq = < /[^']/ > { text }
   def _sgl_seq
-    ( _save = self.pos  # sequence
+    sequence(self.pos,  # sequence
       ( _text_start = self.pos
         scan(/\G(?-mix:[^'])/) &&
         ( text = get_text(_text_start); true )
       ) &&
-      ( @result = (text); true ) ||
-      ( self.pos = _save; nil )  # end sequence
+      ( @result = (text); true )  # end sequence
     ) or set_failed_rule :_sgl_seq
   end
 
   # sgl_not_quote = (sgl_escape_quote | sgl_seq)*:segs { Array(segs) }
   def _sgl_not_quote
-    ( _save = self.pos  # sequence
+    sequence(self.pos,  # sequence
       loop_range(0.., true) {
         ( # choice
           apply(:_sgl_escape_quote) ||
@@ -704,20 +686,18 @@ class KPeg::FormatParser
         )
       } &&
       ( segs = @result; true ) &&
-      ( @result = (Array(segs)); true ) ||
-      ( self.pos = _save; nil )  # end sequence
+      ( @result = (Array(segs)); true )  # end sequence
     ) or set_failed_rule :_sgl_not_quote
   end
 
   # sgl_string = "'" sgl_not_quote:s "'" { @g.str(s.join) }
   def _sgl_string
-    ( _save = self.pos  # sequence
+    sequence(self.pos,  # sequence
       match_string("'") &&
       apply(:_sgl_not_quote) &&
       ( s = @result; true ) &&
       match_string("'") &&
-      ( @result = (@g.str(s.join)); true ) ||
-      ( self.pos = _save; nil )  # end sequence
+      ( @result = (@g.str(s.join)); true )  # end sequence
     ) or set_failed_rule :_sgl_string
   end
 
@@ -732,7 +712,7 @@ class KPeg::FormatParser
 
   # not_slash = < ("\\/" | /[^\/]/)+ > { text }
   def _not_slash
-    ( _save = self.pos  # sequence
+    sequence(self.pos,  # sequence
       ( _text_start = self.pos
         loop_range(1.., false) {
           ( # choice
@@ -743,58 +723,53 @@ class KPeg::FormatParser
         } &&
         ( text = get_text(_text_start); true )
       ) &&
-      ( @result = (text); true ) ||
-      ( self.pos = _save; nil )  # end sequence
+      ( @result = (text); true )  # end sequence
     ) or set_failed_rule :_not_slash
   end
 
   # regexp_opts = < [a-z]* > { text }
   def _regexp_opts
-    ( _save = self.pos  # sequence
+    sequence(self.pos,  # sequence
       ( _text_start = self.pos
         while true  # kleene
-          ( _save1 = self.pos  # char range
+          sequence(self.pos, (  # char range
             _tmp = get_byte
-            _tmp && _tmp >= 97 && _tmp <= 122 ||
-            ( self.pos = _save1; nil )  # end char range
-          ) || (break true) # end kleene
+            _tmp && _tmp >= 97 && _tmp <= 122
+          )) || (break true) # end kleene
         end &&
         ( text = get_text(_text_start); true )
       ) &&
-      ( @result = (text); true ) ||
-      ( self.pos = _save; nil )  # end sequence
+      ( @result = (text); true )  # end sequence
     ) or set_failed_rule :_regexp_opts
   end
 
   # regexp = "/" not_slash:body "/" regexp_opts:opts { @g.reg body, opts }
   def _regexp
-    ( _save = self.pos  # sequence
+    sequence(self.pos,  # sequence
       match_string("/") &&
       apply(:_not_slash) &&
       ( body = @result; true ) &&
       match_string("/") &&
       apply(:_regexp_opts) &&
       ( opts = @result; true ) &&
-      ( @result = (@g.reg body, opts); true ) ||
-      ( self.pos = _save; nil )  # end sequence
+      ( @result = (@g.reg body, opts); true )  # end sequence
     ) or set_failed_rule :_regexp
   end
 
   # char = < /[a-z\d]/i > { text }
   def _char
-    ( _save = self.pos  # sequence
+    sequence(self.pos,  # sequence
       ( _text_start = self.pos
         scan(/\G(?i-mx:[a-z\d])/) &&
         ( text = get_text(_text_start); true )
       ) &&
-      ( @result = (text); true ) ||
-      ( self.pos = _save; nil )  # end sequence
+      ( @result = (text); true )  # end sequence
     ) or set_failed_rule :_char
   end
 
   # char_range = "[" char:l "-" char:r "]" { @g.range(l,r) }
   def _char_range
-    ( _save = self.pos  # sequence
+    sequence(self.pos,  # sequence
       match_string("[") &&
       apply(:_char) &&
       ( l = @result; true ) &&
@@ -802,26 +777,24 @@ class KPeg::FormatParser
       apply(:_char) &&
       ( r = @result; true ) &&
       match_string("]") &&
-      ( @result = (@g.range(l,r)); true ) ||
-      ( self.pos = _save; nil )  # end sequence
+      ( @result = (@g.range(l,r)); true )  # end sequence
     ) or set_failed_rule :_char_range
   end
 
   # range_num = < /[1-9]\d*/ > { text }
   def _range_num
-    ( _save = self.pos  # sequence
+    sequence(self.pos,  # sequence
       ( _text_start = self.pos
         scan(/\G(?-mix:[1-9]\d*)/) &&
         ( text = get_text(_text_start); true )
       ) &&
-      ( @result = (text); true ) ||
-      ( self.pos = _save; nil )  # end sequence
+      ( @result = (text); true )  # end sequence
     ) or set_failed_rule :_range_num
   end
 
   # range_elem = < (range_num | kleene) > { text }
   def _range_elem
-    ( _save = self.pos  # sequence
+    sequence(self.pos,  # sequence
       ( _text_start = self.pos
         ( # choice
           apply(:_range_num) ||
@@ -830,15 +803,14 @@ class KPeg::FormatParser
         ) &&
         ( text = get_text(_text_start); true )
       ) &&
-      ( @result = (text); true ) ||
-      ( self.pos = _save; nil )  # end sequence
+      ( @result = (text); true )  # end sequence
     ) or set_failed_rule :_range_elem
   end
 
   # mult_range = ("[" - range_elem:l - "," - range_elem:r - "]" { [l == "*" ? nil : l.to_i, r == "*" ? nil : r.to_i] } | "[" - range_num:e - "]" { [e.to_i, e.to_i] })
   def _mult_range
     ( # choice
-      ( _save = self.pos  # sequence
+      sequence(self.pos,  # sequence
         match_string("[") &&
         apply(:__hyphen_) &&
         apply(:_range_elem) &&
@@ -850,18 +822,16 @@ class KPeg::FormatParser
         ( r = @result; true ) &&
         apply(:__hyphen_) &&
         match_string("]") &&
-        ( @result = ([l == "*" ? nil : l.to_i, r == "*" ? nil : r.to_i]); true ) ||
-        ( self.pos = _save; nil )  # end sequence
+        ( @result = ([l == "*" ? nil : l.to_i, r == "*" ? nil : r.to_i]); true )  # end sequence
       ) ||
-      ( _save1 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         match_string("[") &&
         apply(:__hyphen_) &&
         apply(:_range_num) &&
         ( e = @result; true ) &&
         apply(:__hyphen_) &&
         match_string("]") &&
-        ( @result = ([e.to_i, e.to_i]); true ) ||
-        ( self.pos = _save1; nil )  # end sequence
+        ( @result = ([e.to_i, e.to_i]); true )  # end sequence
       )
       # end choice
     ) or set_failed_rule :_mult_range
@@ -874,7 +844,7 @@ class KPeg::FormatParser
 
   # curly = "{" < (spaces | /[^{}"']+/ | string | curly)* > "}" { @g.action(text) }
   def _curly
-    ( _save = self.pos  # sequence
+    sequence(self.pos,  # sequence
       match_string("{") &&
       ( _text_start = self.pos
         while true  # kleene
@@ -889,14 +859,13 @@ class KPeg::FormatParser
         ( text = get_text(_text_start); true )
       ) &&
       match_string("}") &&
-      ( @result = (@g.action(text)); true ) ||
-      ( self.pos = _save; nil )  # end sequence
+      ( @result = (@g.action(text)); true )  # end sequence
     ) or set_failed_rule :_curly
   end
 
   # nested_paren = "(" (/[^()"']+/ | string | nested_paren)* ")"
   def _nested_paren
-    ( _save = self.pos  # sequence
+    sequence(self.pos,  # sequence
       match_string("(") &&
       while true  # kleene
         ( # choice
@@ -906,153 +875,136 @@ class KPeg::FormatParser
           # end choice
         ) || (break true) # end kleene
       end &&
-      match_string(")") ||
-      ( self.pos = _save; nil )  # end sequence
+      match_string(")")  # end sequence
     ) or set_failed_rule :_nested_paren
   end
 
   # value = (value:v ":" var:n { @g.t(v,n) } | value:v "?" { @g.maybe(v) } | value:v "+" { @g.many(v) } | value:v "*" { @g.kleene(v) } | value:v mult_range:r { @g.multiple(v, *r) } | "&" value:v { @g.andp(v) } | "!" value:v { @g.notp(v) } | "(" - expression:o - ")" { o } | "@<" - expression:o - ">" { @g.bounds(o) } | "<" - expression:o - ">" { @g.collect(o) } | curly_block | "~" method:m < nested_paren? > { @g.action("#{m}#{text}") } | "." { @g.dot } | "@" var:name < nested_paren? > !(- "=") { @g.invoke(name, text.empty? ? nil : text) } | "^" var:name < nested_paren? > { @g.foreign_invoke("parent", name, text) } | "%" var:gram "." var:name < nested_paren? > { @g.foreign_invoke(gram, name, text) } | var:name < nested_paren? > !(- "=") { @g.ref(name, nil, text.empty? ? nil : text) } | char_range | regexp | string)
   def _value
     ( # choice
-      ( _save = self.pos  # sequence
+      sequence(self.pos,  # sequence
         apply(:_value) &&
         ( v = @result; true ) &&
         match_string(":") &&
         apply(:_var) &&
         ( n = @result; true ) &&
-        ( @result = (@g.t(v,n)); true ) ||
-        ( self.pos = _save; nil )  # end sequence
+        ( @result = (@g.t(v,n)); true )  # end sequence
       ) ||
-      ( _save1 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         apply(:_value) &&
         ( v = @result; true ) &&
         match_string("?") &&
-        ( @result = (@g.maybe(v)); true ) ||
-        ( self.pos = _save1; nil )  # end sequence
+        ( @result = (@g.maybe(v)); true )  # end sequence
       ) ||
-      ( _save2 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         apply(:_value) &&
         ( v = @result; true ) &&
         match_string("+") &&
-        ( @result = (@g.many(v)); true ) ||
-        ( self.pos = _save2; nil )  # end sequence
+        ( @result = (@g.many(v)); true )  # end sequence
       ) ||
-      ( _save3 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         apply(:_value) &&
         ( v = @result; true ) &&
         match_string("*") &&
-        ( @result = (@g.kleene(v)); true ) ||
-        ( self.pos = _save3; nil )  # end sequence
+        ( @result = (@g.kleene(v)); true )  # end sequence
       ) ||
-      ( _save4 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         apply(:_value) &&
         ( v = @result; true ) &&
         apply(:_mult_range) &&
         ( r = @result; true ) &&
-        ( @result = (@g.multiple(v, *r)); true ) ||
-        ( self.pos = _save4; nil )  # end sequence
+        ( @result = (@g.multiple(v, *r)); true )  # end sequence
       ) ||
-      ( _save5 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         match_string("&") &&
         apply(:_value) &&
         ( v = @result; true ) &&
-        ( @result = (@g.andp(v)); true ) ||
-        ( self.pos = _save5; nil )  # end sequence
+        ( @result = (@g.andp(v)); true )  # end sequence
       ) ||
-      ( _save6 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         match_string("!") &&
         apply(:_value) &&
         ( v = @result; true ) &&
-        ( @result = (@g.notp(v)); true ) ||
-        ( self.pos = _save6; nil )  # end sequence
+        ( @result = (@g.notp(v)); true )  # end sequence
       ) ||
-      ( _save7 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         match_string("(") &&
         apply(:__hyphen_) &&
         apply(:_expression) &&
         ( o = @result; true ) &&
         apply(:__hyphen_) &&
         match_string(")") &&
-        ( @result = (o); true ) ||
-        ( self.pos = _save7; nil )  # end sequence
+        ( @result = (o); true )  # end sequence
       ) ||
-      ( _save8 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         match_string("@<") &&
         apply(:__hyphen_) &&
         apply(:_expression) &&
         ( o = @result; true ) &&
         apply(:__hyphen_) &&
         match_string(">") &&
-        ( @result = (@g.bounds(o)); true ) ||
-        ( self.pos = _save8; nil )  # end sequence
+        ( @result = (@g.bounds(o)); true )  # end sequence
       ) ||
-      ( _save9 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         match_string("<") &&
         apply(:__hyphen_) &&
         apply(:_expression) &&
         ( o = @result; true ) &&
         apply(:__hyphen_) &&
         match_string(">") &&
-        ( @result = (@g.collect(o)); true ) ||
-        ( self.pos = _save9; nil )  # end sequence
+        ( @result = (@g.collect(o)); true )  # end sequence
       ) ||
       apply(:_curly_block) ||
-      ( _save10 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         match_string("~") &&
         apply(:_method) &&
         ( m = @result; true ) &&
         ( _text_start = self.pos
-          ( _save11 = self.pos  # optional
+          (  # optional
             apply(:_nested_paren) ||
-            ( self.pos = _save11; true )  # end optional
+            true  # end optional
           ) &&
           ( text = get_text(_text_start); true )
         ) &&
-        ( @result = (@g.action("#{m}#{text}")); true ) ||
-        ( self.pos = _save10; nil )  # end sequence
+        ( @result = (@g.action("#{m}#{text}")); true )  # end sequence
       ) ||
-      ( _save12 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         match_string(".") &&
-        ( @result = (@g.dot); true ) ||
-        ( self.pos = _save12; nil )  # end sequence
+        ( @result = (@g.dot); true )  # end sequence
       ) ||
-      ( _save13 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         match_string("@") &&
         apply(:_var) &&
         ( name = @result; true ) &&
         ( _text_start = self.pos
-          ( _save14 = self.pos  # optional
+          (  # optional
             apply(:_nested_paren) ||
-            ( self.pos = _save14; true )  # end optional
+            true  # end optional
           ) &&
           ( text = get_text(_text_start); true )
         ) &&
-        ( _save15 = self.pos
-          look_ahead(_save15, !(
-            ( _save16 = self.pos  # sequence
-              apply(:__hyphen_) &&
-              match_string("=") ||
-              ( self.pos = _save16; nil )  # end sequence
-            )  # end negation
-        ))) &&
-        ( @result = (@g.invoke(name, text.empty? ? nil : text)); true ) ||
-        ( self.pos = _save13; nil )  # end sequence
+        look_negation(self.pos,
+          sequence(self.pos,  # sequence
+            apply(:__hyphen_) &&
+            match_string("=")  # end sequence
+          )  # end negation
+        ) &&
+        ( @result = (@g.invoke(name, text.empty? ? nil : text)); true )  # end sequence
       ) ||
-      ( _save17 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         match_string("^") &&
         apply(:_var) &&
         ( name = @result; true ) &&
         ( _text_start = self.pos
-          ( _save18 = self.pos  # optional
+          (  # optional
             apply(:_nested_paren) ||
-            ( self.pos = _save18; true )  # end optional
+            true  # end optional
           ) &&
           ( text = get_text(_text_start); true )
         ) &&
-        ( @result = (@g.foreign_invoke("parent", name, text)); true ) ||
-        ( self.pos = _save17; nil )  # end sequence
+        ( @result = (@g.foreign_invoke("parent", name, text)); true )  # end sequence
       ) ||
-      ( _save19 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         match_string("%") &&
         apply(:_var) &&
         ( gram = @result; true ) &&
@@ -1060,35 +1012,31 @@ class KPeg::FormatParser
         apply(:_var) &&
         ( name = @result; true ) &&
         ( _text_start = self.pos
-          ( _save20 = self.pos  # optional
+          (  # optional
             apply(:_nested_paren) ||
-            ( self.pos = _save20; true )  # end optional
+            true  # end optional
           ) &&
           ( text = get_text(_text_start); true )
         ) &&
-        ( @result = (@g.foreign_invoke(gram, name, text)); true ) ||
-        ( self.pos = _save19; nil )  # end sequence
+        ( @result = (@g.foreign_invoke(gram, name, text)); true )  # end sequence
       ) ||
-      ( _save21 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         apply(:_var) &&
         ( name = @result; true ) &&
         ( _text_start = self.pos
-          ( _save22 = self.pos  # optional
+          (  # optional
             apply(:_nested_paren) ||
-            ( self.pos = _save22; true )  # end optional
+            true  # end optional
           ) &&
           ( text = get_text(_text_start); true )
         ) &&
-        ( _save23 = self.pos
-          look_ahead(_save23, !(
-            ( _save24 = self.pos  # sequence
-              apply(:__hyphen_) &&
-              match_string("=") ||
-              ( self.pos = _save24; nil )  # end sequence
-            )  # end negation
-        ))) &&
-        ( @result = (@g.ref(name, nil, text.empty? ? nil : text)); true ) ||
-        ( self.pos = _save21; nil )  # end sequence
+        look_negation(self.pos,
+          sequence(self.pos,  # sequence
+            apply(:__hyphen_) &&
+            match_string("=")  # end sequence
+          )  # end negation
+        ) &&
+        ( @result = (@g.ref(name, nil, text.empty? ? nil : text)); true )  # end sequence
       ) ||
       apply(:_char_range) ||
       apply(:_regexp) ||
@@ -1111,23 +1059,21 @@ class KPeg::FormatParser
   # values = (values:s spaces value:v { @g.seq(s, v) } | value:l spaces value:r { @g.seq(l, r) } | value)
   def _values
     ( # choice
-      ( _save = self.pos  # sequence
+      sequence(self.pos,  # sequence
         apply(:_values) &&
         ( s = @result; true ) &&
         apply(:_spaces) &&
         apply(:_value) &&
         ( v = @result; true ) &&
-        ( @result = (@g.seq(s, v)); true ) ||
-        ( self.pos = _save; nil )  # end sequence
+        ( @result = (@g.seq(s, v)); true )  # end sequence
       ) ||
-      ( _save1 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         apply(:_value) &&
         ( l = @result; true ) &&
         apply(:_spaces) &&
         apply(:_value) &&
         ( r = @result; true ) &&
-        ( @result = (@g.seq(l, r)); true ) ||
-        ( self.pos = _save1; nil )  # end sequence
+        ( @result = (@g.seq(l, r)); true )  # end sequence
       ) ||
       apply(:_value)
       # end choice
@@ -1136,29 +1082,27 @@ class KPeg::FormatParser
 
   # choose_cont = - "|" - values:v { v }
   def _choose_cont
-    ( _save = self.pos  # sequence
+    sequence(self.pos,  # sequence
       apply(:__hyphen_) &&
       match_string("|") &&
       apply(:__hyphen_) &&
       apply(:_values) &&
       ( v = @result; true ) &&
-      ( @result = (v); true ) ||
-      ( self.pos = _save; nil )  # end sequence
+      ( @result = (v); true )  # end sequence
     ) or set_failed_rule :_choose_cont
   end
 
   # expression = (values:v choose_cont+:alts { @g.any(v, *alts) } | values)
   def _expression
     ( # choice
-      ( _save = self.pos  # sequence
+      sequence(self.pos,  # sequence
         apply(:_values) &&
         ( v = @result; true ) &&
         loop_range(1.., true) {
           apply(:_choose_cont)
         } &&
         ( alts = @result; true ) &&
-        ( @result = (@g.any(v, *alts)); true ) ||
-        ( self.pos = _save; nil )  # end sequence
+        ( @result = (@g.any(v, *alts)); true )  # end sequence
       ) ||
       apply(:_values)
       # end choice
@@ -1168,7 +1112,7 @@ class KPeg::FormatParser
   # args = (args:a "," - var:n - { a + [n] } | - var:n - { [n] })
   def _args
     ( # choice
-      ( _save = self.pos  # sequence
+      sequence(self.pos,  # sequence
         apply(:_args) &&
         ( a = @result; true ) &&
         match_string(",") &&
@@ -1176,16 +1120,14 @@ class KPeg::FormatParser
         apply(:_var) &&
         ( n = @result; true ) &&
         apply(:__hyphen_) &&
-        ( @result = (a + [n]); true ) ||
-        ( self.pos = _save; nil )  # end sequence
+        ( @result = (a + [n]); true )  # end sequence
       ) ||
-      ( _save1 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         apply(:__hyphen_) &&
         apply(:_var) &&
         ( n = @result; true ) &&
         apply(:__hyphen_) &&
-        ( @result = ([n]); true ) ||
-        ( self.pos = _save1; nil )  # end sequence
+        ( @result = ([n]); true )  # end sequence
       )
       # end choice
     ) or set_failed_rule :_args
@@ -1194,7 +1136,7 @@ class KPeg::FormatParser
   # statement = (- var:v "(" args:a ")" - "=" - expression:o { @g.set(v, o, a) } | - var:v - "=" - expression:o { @g.set(v, o) } | - "%" var:name - "=" - < /[:\w]+/ > { @g.add_foreign_grammar(name, text) } | - "%%" - curly:act { @g.add_setup act } | - "%%" - var:name - curly:act { @g.add_directive name, act } | - "%%" - var:name - "=" - < (!"\n" .)+ > { @g.set_variable(name, text) })
   def _statement
     ( # choice
-      ( _save = self.pos  # sequence
+      sequence(self.pos,  # sequence
         apply(:__hyphen_) &&
         apply(:_var) &&
         ( v = @result; true ) &&
@@ -1207,10 +1149,9 @@ class KPeg::FormatParser
         apply(:__hyphen_) &&
         apply(:_expression) &&
         ( o = @result; true ) &&
-        ( @result = (@g.set(v, o, a)); true ) ||
-        ( self.pos = _save; nil )  # end sequence
+        ( @result = (@g.set(v, o, a)); true )  # end sequence
       ) ||
-      ( _save1 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         apply(:__hyphen_) &&
         apply(:_var) &&
         ( v = @result; true ) &&
@@ -1219,10 +1160,9 @@ class KPeg::FormatParser
         apply(:__hyphen_) &&
         apply(:_expression) &&
         ( o = @result; true ) &&
-        ( @result = (@g.set(v, o)); true ) ||
-        ( self.pos = _save1; nil )  # end sequence
+        ( @result = (@g.set(v, o)); true )  # end sequence
       ) ||
-      ( _save2 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         apply(:__hyphen_) &&
         match_string("%") &&
         apply(:_var) &&
@@ -1234,19 +1174,17 @@ class KPeg::FormatParser
           scan(/\G(?-mix:[:\w]+)/) &&
           ( text = get_text(_text_start); true )
         ) &&
-        ( @result = (@g.add_foreign_grammar(name, text)); true ) ||
-        ( self.pos = _save2; nil )  # end sequence
+        ( @result = (@g.add_foreign_grammar(name, text)); true )  # end sequence
       ) ||
-      ( _save3 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         apply(:__hyphen_) &&
         match_string("%%") &&
         apply(:__hyphen_) &&
         apply(:_curly) &&
         ( act = @result; true ) &&
-        ( @result = (@g.add_setup act); true ) ||
-        ( self.pos = _save3; nil )  # end sequence
+        ( @result = (@g.add_setup act); true )  # end sequence
       ) ||
-      ( _save4 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         apply(:__hyphen_) &&
         match_string("%%") &&
         apply(:__hyphen_) &&
@@ -1255,10 +1193,9 @@ class KPeg::FormatParser
         apply(:__hyphen_) &&
         apply(:_curly) &&
         ( act = @result; true ) &&
-        ( @result = (@g.add_directive name, act); true ) ||
-        ( self.pos = _save4; nil )  # end sequence
+        ( @result = (@g.add_directive name, act); true )  # end sequence
       ) ||
-      ( _save5 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         apply(:__hyphen_) &&
         match_string("%%") &&
         apply(:__hyphen_) &&
@@ -1269,19 +1206,16 @@ class KPeg::FormatParser
         apply(:__hyphen_) &&
         ( _text_start = self.pos
           loop_range(1.., false) {
-            ( _save6 = self.pos  # sequence
-              ( _save7 = self.pos
-                look_ahead(_save7, !(
-                  match_string("\n")  # end negation
-              ))) &&
-              get_byte ||
-              ( self.pos = _save6; nil )  # end sequence
+            sequence(self.pos,  # sequence
+              look_negation(self.pos,
+                match_string("\n")  # end negation
+              ) &&
+              get_byte  # end sequence
             )
           } &&
           ( text = get_text(_text_start); true )
         ) &&
-        ( @result = (@g.set_variable(name, text)); true ) ||
-        ( self.pos = _save5; nil )  # end sequence
+        ( @result = (@g.set_variable(name, text)); true )  # end sequence
       )
       # end choice
     ) or set_failed_rule :_statement
@@ -1289,63 +1223,57 @@ class KPeg::FormatParser
 
   # statements = statement (- statements)?
   def _statements
-    ( _save = self.pos  # sequence
+    sequence(self.pos,  # sequence
       apply(:_statement) &&
-      ( _save1 = self.pos  # optional
-        ( _save2 = self.pos  # sequence
+      (  # optional
+        sequence(self.pos,  # sequence
           apply(:__hyphen_) &&
-          apply(:_statements) ||
-          ( self.pos = _save2; nil )  # end sequence
+          apply(:_statements)  # end sequence
         ) ||
-        ( self.pos = _save1; true )  # end optional
-      ) ||
-      ( self.pos = _save; nil )  # end sequence
+        true  # end optional
+      )  # end sequence
     ) or set_failed_rule :_statements
   end
 
   # eof = !.
   def _eof
-    ( _save = self.pos
-      look_ahead(_save, !(
-        get_byte  # end negation
-    ))) or set_failed_rule :_eof
+    look_negation(self.pos,
+      get_byte  # end negation
+    ) or set_failed_rule :_eof
   end
 
   # root = statements - eof_comment? eof
   def _root
-    ( _save = self.pos  # sequence
+    sequence(self.pos,  # sequence
       apply(:_statements) &&
       apply(:__hyphen_) &&
-      ( _save1 = self.pos  # optional
+      (  # optional
         apply(:_eof_comment) ||
-        ( self.pos = _save1; true )  # end optional
+        true  # end optional
       ) &&
-      apply(:_eof) ||
-      ( self.pos = _save; nil )  # end sequence
+      apply(:_eof)  # end sequence
     ) or set_failed_rule :_root
   end
 
   # ast_constant = < /[A-Z]\w*/ > { text }
   def _ast_constant
-    ( _save = self.pos  # sequence
+    sequence(self.pos,  # sequence
       ( _text_start = self.pos
         scan(/\G(?-mix:[A-Z]\w*)/) &&
         ( text = get_text(_text_start); true )
       ) &&
-      ( @result = (text); true ) ||
-      ( self.pos = _save; nil )  # end sequence
+      ( @result = (text); true )  # end sequence
     ) or set_failed_rule :_ast_constant
   end
 
   # ast_word = < /[a-z_]\w*/i > { text }
   def _ast_word
-    ( _save = self.pos  # sequence
+    sequence(self.pos,  # sequence
       ( _text_start = self.pos
         scan(/\G(?i-mx:[a-z_]\w*)/) &&
         ( text = get_text(_text_start); true )
       ) &&
-      ( @result = (text); true ) ||
-      ( self.pos = _save; nil )  # end sequence
+      ( @result = (text); true )  # end sequence
     ) or set_failed_rule :_ast_word
   end
 
@@ -1363,7 +1291,7 @@ class KPeg::FormatParser
   # ast_words = (ast_words:r ast_sp "," ast_sp ast_word:w { r + [w] } | ast_word:w { [w] })
   def _ast_words
     ( # choice
-      ( _save = self.pos  # sequence
+      sequence(self.pos,  # sequence
         apply(:_ast_words) &&
         ( r = @result; true ) &&
         apply(:_ast_sp) &&
@@ -1371,14 +1299,12 @@ class KPeg::FormatParser
         apply(:_ast_sp) &&
         apply(:_ast_word) &&
         ( w = @result; true ) &&
-        ( @result = (r + [w]); true ) ||
-        ( self.pos = _save; nil )  # end sequence
+        ( @result = (r + [w]); true )  # end sequence
       ) ||
-      ( _save1 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         apply(:_ast_word) &&
         ( w = @result; true ) &&
-        ( @result = ([w]); true ) ||
-        ( self.pos = _save1; nil )  # end sequence
+        ( @result = ([w]); true )  # end sequence
       )
       # end choice
     ) or set_failed_rule :_ast_words
@@ -1387,25 +1313,23 @@ class KPeg::FormatParser
   # ast_root = (ast_constant:c "(" ast_words:w ")" { [c, w] } | ast_constant:c "()"? { [c, []] })
   def _ast_root
     ( # choice
-      ( _save = self.pos  # sequence
+      sequence(self.pos,  # sequence
         apply(:_ast_constant) &&
         ( c = @result; true ) &&
         match_string("(") &&
         apply(:_ast_words) &&
         ( w = @result; true ) &&
         match_string(")") &&
-        ( @result = ([c, w]); true ) ||
-        ( self.pos = _save; nil )  # end sequence
+        ( @result = ([c, w]); true )  # end sequence
       ) ||
-      ( _save1 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         apply(:_ast_constant) &&
         ( c = @result; true ) &&
-        ( _save2 = self.pos  # optional
+        (  # optional
           match_string("()") ||
-          ( self.pos = _save2; true )  # end optional
+          true  # end optional
         ) &&
-        ( @result = ([c, []]); true ) ||
-        ( self.pos = _save1; nil )  # end sequence
+        ( @result = ([c, []]); true )  # end sequence
       )
       # end choice
     ) or set_failed_rule :_ast_root

--- a/lib/kpeg/format_parser.rb
+++ b/lib/kpeg/format_parser.rb
@@ -45,6 +45,9 @@ class KPeg::FormatParser
       def current_line(target=pos)
         if line = position_line_offsets.bsearch_index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
         raise "Target position #{target} is outside of string"
       end
@@ -52,17 +55,22 @@ class KPeg::FormatParser
       def current_line(target=pos)
         if line = position_line_offsets.index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
-
         raise "Target position #{target} is outside of string"
       end
     end
 
     def current_character(target=pos)
-      if target < 0 || target >= string.size
+      if target < 0 || target > string.size
         raise "Target position #{target} is outside of string"
+      elsif target == string.size
+        ""
+      else
+        string[target, 1]
       end
-      string[target, 1]
     end
 
     KpegPosInfo = Struct.new(:pos, :lno, :col, :line, :char)

--- a/lib/kpeg/position.rb
+++ b/lib/kpeg/position.rb
@@ -28,6 +28,9 @@ module KPeg
       def current_line(target=pos)
         if line = position_line_offsets.bsearch_index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
         raise "Target position #{target} is outside of string"
       end
@@ -35,17 +38,22 @@ module KPeg
       def current_line(target=pos)
         if line = position_line_offsets.index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
-
         raise "Target position #{target} is outside of string"
       end
     end
 
     def current_character(target=pos)
-      if target < 0 || target >= string.size
+      if target < 0 || target > string.size
         raise "Target position #{target} is outside of string"
+      elsif target == string.size
+        ""
+      else
+        string[target, 1]
       end
-      string[target, 1]
     end
 
     KpegPosInfo = Struct.new(:pos, :lno, :col, :line, :char)

--- a/lib/kpeg/string_escape.rb
+++ b/lib/kpeg/string_escape.rb
@@ -239,9 +239,19 @@ class KPeg::StringEscape
       end
     end
 
+    def sequence(pos, action)
+      @pos = pos  unless action
+      action ? true : nil
+    end
+
     def look_ahead(pos, action)
       @pos = pos
       action ? true : nil
+    end
+
+    def look_negation(pos, action)
+      @pos = pos
+      action ? nil : true
     end
 
     def loop_range(range, store)
@@ -434,51 +444,43 @@ class KPeg::StringEscape
   # segment = (< /[\w ]+/ > { text } | "\\" { "\\\\" } | "\n" { "\\n" } | "\r" { "\\r" } | "\t" { "\\t" } | "\b" { "\\b" } | "\"" { "\\\"" } | < . > { text })
   def _segment
     ( # choice
-      ( _save = self.pos  # sequence
+      sequence(self.pos,  # sequence
         ( _text_start = self.pos
           scan(/\G(?-mix:[\w ]+)/) &&
           ( text = get_text(_text_start); true )
         ) &&
-        ( @result = (text); true ) ||
-        ( self.pos = _save; nil )  # end sequence
+        ( @result = (text); true )  # end sequence
       ) ||
-      ( _save1 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         match_string("\\") &&
-        ( @result = ("\\\\"); true ) ||
-        ( self.pos = _save1; nil )  # end sequence
+        ( @result = ("\\\\"); true )  # end sequence
       ) ||
-      ( _save2 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         match_string("\n") &&
-        ( @result = ("\\n"); true ) ||
-        ( self.pos = _save2; nil )  # end sequence
+        ( @result = ("\\n"); true )  # end sequence
       ) ||
-      ( _save3 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         match_string("\r") &&
-        ( @result = ("\\r"); true ) ||
-        ( self.pos = _save3; nil )  # end sequence
+        ( @result = ("\\r"); true )  # end sequence
       ) ||
-      ( _save4 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         match_string("\t") &&
-        ( @result = ("\\t"); true ) ||
-        ( self.pos = _save4; nil )  # end sequence
+        ( @result = ("\\t"); true )  # end sequence
       ) ||
-      ( _save5 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         match_string("\b") &&
-        ( @result = ("\\b"); true ) ||
-        ( self.pos = _save5; nil )  # end sequence
+        ( @result = ("\\b"); true )  # end sequence
       ) ||
-      ( _save6 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         match_string("\"") &&
-        ( @result = ("\\\""); true ) ||
-        ( self.pos = _save6; nil )  # end sequence
+        ( @result = ("\\\""); true )  # end sequence
       ) ||
-      ( _save7 = self.pos  # sequence
+      sequence(self.pos,  # sequence
         ( _text_start = self.pos
           get_byte &&
           ( text = get_text(_text_start); true )
         ) &&
-        ( @result = (text); true ) ||
-        ( self.pos = _save7; nil )  # end sequence
+        ( @result = (text); true )  # end sequence
       )
       # end choice
     ) or set_failed_rule :_segment
@@ -486,23 +488,21 @@ class KPeg::StringEscape
 
   # root = segment*:s { @text = s.join }
   def _root
-    ( _save = self.pos  # sequence
+    sequence(self.pos,  # sequence
       loop_range(0.., true) {
         apply(:_segment)
       } &&
       ( s = @result; true ) &&
-      ( @result = (@text = s.join); true ) ||
-      ( self.pos = _save; nil )  # end sequence
+      ( @result = (@text = s.join); true )  # end sequence
     ) or set_failed_rule :_root
   end
 
   # embed_seg = ("#" { "\\#" } | segment)
   def _embed_seg
     ( # choice
-      ( _save = self.pos  # sequence
+      sequence(self.pos,  # sequence
         match_string("#") &&
-        ( @result = ("\\#"); true ) ||
-        ( self.pos = _save; nil )  # end sequence
+        ( @result = ("\\#"); true )  # end sequence
       ) ||
       apply(:_segment)
       # end choice
@@ -511,13 +511,12 @@ class KPeg::StringEscape
 
   # embed = embed_seg*:s { @text = s.join }
   def _embed
-    ( _save = self.pos  # sequence
+    sequence(self.pos,  # sequence
       loop_range(0.., true) {
         apply(:_embed_seg)
       } &&
       ( s = @result; true ) &&
-      ( @result = (@text = s.join); true ) ||
-      ( self.pos = _save; nil )  # end sequence
+      ( @result = (@text = s.join); true )  # end sequence
     ) or set_failed_rule :_embed
   end
 

--- a/lib/kpeg/string_escape.rb
+++ b/lib/kpeg/string_escape.rb
@@ -53,6 +53,9 @@ class KPeg::StringEscape
       def current_line(target=pos)
         if line = position_line_offsets.bsearch_index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
         raise "Target position #{target} is outside of string"
       end
@@ -60,17 +63,22 @@ class KPeg::StringEscape
       def current_line(target=pos)
         if line = position_line_offsets.index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
-
         raise "Target position #{target} is outside of string"
       end
     end
 
     def current_character(target=pos)
-      if target < 0 || target >= string.size
+      if target < 0 || target > string.size
         raise "Target position #{target} is outside of string"
+      elsif target == string.size
+        ""
+      else
+        string[target, 1]
       end
-      string[target, 1]
     end
 
     KpegPosInfo = Struct.new(:pos, :lno, :col, :line, :char)

--- a/test/test_kpeg_code_generator.rb
+++ b/test/test_kpeg_code_generator.rb
@@ -155,11 +155,10 @@ class Test < KPeg::CompiledParser
 
   # root = [a-z]
   def _root
-    ( _save = self.pos  # char range
+    sequence(self.pos, (  # char range
       _tmp = get_byte
-      _tmp && _tmp >= 97 && _tmp <= 122 ||
-      ( self.pos = _save; nil )  # end char range
-    ) or set_failed_rule :_root
+      _tmp && _tmp >= 97 && _tmp <= 122
+    )) or set_failed_rule :_root
   end
 
   Rules = {}
@@ -190,14 +189,12 @@ class Test < KPeg::CompiledParser
 
   # root = [a-z] "hello"
   def _root
-    ( _save = self.pos  # sequence
-      ( _save1 = self.pos  # char range
+    sequence(self.pos,  # sequence
+      sequence(self.pos, (  # char range
         _tmp = get_byte
-        _tmp && _tmp >= 97 && _tmp <= 122 ||
-        ( self.pos = _save1; nil )  # end char range
-      ) &&
-      match_string("hello") ||
-      ( self.pos = _save; nil )  # end sequence
+        _tmp && _tmp >= 97 && _tmp <= 122
+      )) &&
+      match_string("hello")  # end sequence
     ) or set_failed_rule :_root
   end
 
@@ -279,9 +276,9 @@ class Test < KPeg::CompiledParser
 
   # root = "hello"?
   def _root
-    ( _save = self.pos  # optional
+    (  # optional
       match_string("hello") ||
-      ( self.pos = _save; true )  # end optional
+      true  # end optional
     ) or set_failed_rule :_root
   end
 
@@ -460,10 +457,9 @@ class Test < KPeg::CompiledParser
 
   # root = "hello" "world"
   def _root
-    ( _save = self.pos  # sequence
+    sequence(self.pos,  # sequence
       match_string("hello") &&
-      match_string("world") ||
-      ( self.pos = _save; nil )  # end sequence
+      match_string("world")  # end sequence
     ) or set_failed_rule :_root
   end
 
@@ -506,10 +502,9 @@ class Test < KPeg::CompiledParser
 
   # root = &"hello"
   def _root
-    ( _save = self.pos
-      look_ahead(_save,
-        match_string("hello")  # end look ahead
-    )) or set_failed_rule :_root
+    look_ahead(self.pos,
+      match_string("hello")  # end look ahead
+    ) or set_failed_rule :_root
   end
 
   Rules = {}
@@ -544,10 +539,9 @@ class Test < KPeg::CompiledParser
 
   # root = &{ !defined? @fail }
   def _root
-    ( _save = self.pos
-      look_ahead(_save,
-        !defined? @fail  # end look ahead
-    )) or set_failed_rule :_root
+    look_ahead(self.pos,
+      !defined? @fail  # end look ahead
+    ) or set_failed_rule :_root
   end
 
   Rules = {}
@@ -583,10 +577,9 @@ class Test < KPeg::CompiledParser
 
   # root = !"hello"
   def _root
-    ( _save = self.pos
-      look_ahead(_save, !(
-        match_string("hello")  # end negation
-    ))) or set_failed_rule :_root
+    look_negation(self.pos,
+      match_string("hello")  # end negation
+    ) or set_failed_rule :_root
   end
 
   Rules = {}
@@ -621,10 +614,9 @@ class Test < KPeg::CompiledParser
 
   # root = !{ defined? @fail }
   def _root
-    ( _save = self.pos
-      look_ahead(_save, !(
-        defined? @fail  # end negation
-    ))) or set_failed_rule :_root
+    look_negation(self.pos,
+      defined? @fail  # end negation
+    ) or set_failed_rule :_root
   end
 
   Rules = {}
@@ -898,26 +890,24 @@ class Test < KPeg::CompiledParser
 
   # hello = < "hello" > {text}
   def _hello
-    ( _save = self.pos  # sequence
+    sequence(self.pos,  # sequence
       ( _text_start = self.pos
         match_string("hello") &&
         ( text = get_text(_text_start); true )
       ) &&
-      ( @result = (text); true ) ||
-      ( self.pos = _save; nil )  # end sequence
+      ( @result = (text); true )  # end sequence
     ) or set_failed_rule :_hello
   end
 
   # root = hello?:lots {lots}
   def _root
-    ( _save = self.pos  # sequence
-      ( _save1 = self.pos  # optional
+    sequence(self.pos,  # sequence
+      (  # optional
         apply(:_hello) ||
-        ( self.pos = _save1; @result = nil; true )  # end optional
+        ( @result = nil; true )  # end optional
       ) &&
       ( lots = @result; true ) &&
-      ( @result = (lots); true ) ||
-      ( self.pos = _save; nil )  # end sequence
+      ( @result = (lots); true )  # end sequence
     ) or set_failed_rule :_root
   end
 
@@ -956,25 +946,23 @@ class Test < KPeg::CompiledParser
 
   # hello = < "hello" > {text}
   def _hello
-    ( _save = self.pos  # sequence
+    sequence(self.pos,  # sequence
       ( _text_start = self.pos
         match_string("hello") &&
         ( text = get_text(_text_start); true )
       ) &&
-      ( @result = (text); true ) ||
-      ( self.pos = _save; nil )  # end sequence
+      ( @result = (text); true )  # end sequence
     ) or set_failed_rule :_hello
   end
 
   # root = hello*:lots {lots}
   def _root
-    ( _save = self.pos  # sequence
+    sequence(self.pos,  # sequence
       loop_range(0.., true) {
         apply(:_hello)
       } &&
       ( lots = @result; true ) &&
-      ( @result = (lots); true ) ||
-      ( self.pos = _save; nil )  # end sequence
+      ( @result = (lots); true )  # end sequence
     ) or set_failed_rule :_root
   end
 
@@ -1016,25 +1004,23 @@ class Test < KPeg::CompiledParser
 
   # hello = < "hello" > {text}
   def _hello
-    ( _save = self.pos  # sequence
+    sequence(self.pos,  # sequence
       ( _text_start = self.pos
         match_string("hello") &&
         ( text = get_text(_text_start); true )
       ) &&
-      ( @result = (text); true ) ||
-      ( self.pos = _save; nil )  # end sequence
+      ( @result = (text); true )  # end sequence
     ) or set_failed_rule :_hello
   end
 
   # root = hello+:lots {lots}
   def _root
-    ( _save = self.pos  # sequence
+    sequence(self.pos,  # sequence
       loop_range(1.., true) {
         apply(:_hello)
       } &&
       ( lots = @result; true ) &&
-      ( @result = (lots); true ) ||
-      ( self.pos = _save; nil )  # end sequence
+      ( @result = (lots); true )  # end sequence
     ) or set_failed_rule :_root
   end
 
@@ -1105,13 +1091,12 @@ class Test < KPeg::CompiledParser
 
   # root = < "hello" > { text }
   def _root
-    ( _save = self.pos  # sequence
+    sequence(self.pos,  # sequence
       ( _text_start = self.pos
         match_string("hello") &&
         ( text = get_text(_text_start); true )
       ) &&
-      ( @result = (text); true ) ||
-      ( self.pos = _save; nil )  # end sequence
+      ( @result = (text); true )  # end sequence
     ) or set_failed_rule :_root
   end
 
@@ -1143,13 +1128,12 @@ class Test < KPeg::CompiledParser
 
   # root = @< "hello" > { bounds }
   def _root
-    ( _save = self.pos  # sequence
+    sequence(self.pos,  # sequence
       ( _bounds_start = self.pos
         match_string("hello") &&
         (bounds = [_bounds_start, self.pos]; true )
       ) &&
-      ( @result = (bounds); true ) ||
-      ( self.pos = _save; nil )  # end sequence
+      ( @result = (bounds); true )  # end sequence
     ) or set_failed_rule :_root
   end
 


### PR DESCRIPTION
1. in sequences replace `while` + `break unless _tmp` with short-circuit
  `&&` evaluation
2. in choices replace `whicl` + `break if _tmp` with short-circuit
  `||` evaluation
3. in choices there's no need to restore position before each choice, since
  failed choice restore it by itself
4. look ahead is wrapped in tiny method to simplify position returning.
   It should not affect performance much.
5. repetitions are implemented with method taking block.
  Certainly it is slower a bit, but code simplifies a lot.
  Cons: `tags` in repetition become local block variable and could be
  invisible for outer action, so it is a bit backward incompatible.


First commit ( c06b8df1a4ebd1e0e16987998f2cc32929a1e35f ) is a fix for tiny_markdown example and could be committed separately.
tiny_markdown were broken with cf8f511644d5b1c5bb88fd4060f02c3a0e1f7633 .