### PR TITLE
Allow position to target just at string end (past last char)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -23,20 +23,38 @@ rule ".rb" => ".kpeg" do |t|
   ruby "-Ilib bin/kpeg -s -o #{t.name} -f #{t.source}"
 end
 
+rule ".kpeg.rb" => ".kpeg" do |t|
+  ruby "-Ilib bin/kpeg -s -o #{t.name} -f #{t.source}"
+end
+
 PARSER_FILES = %w[
   lib/kpeg/string_escape.rb
   lib/kpeg/format_parser.rb
 ]
 
-PARSER_FILES.map do |parser_file|
+PARSER_FILES.each do |parser_file|
   file parser_file => 'lib/kpeg/compiled_parser.rb'
   file parser_file => 'lib/kpeg/code_generator.rb'
   file parser_file => 'lib/kpeg/position.rb'
   file parser_file => parser_file.sub(/\.rb$/, '.kpeg')
 end
 
+EXAMPLE_FILES = Dir.glob('examples/*/*.kpeg').map{|f| f + ".rb" }
+
+EXAMPLE_FILES.each do |example_file|
+  file example_file => 'lib/kpeg/compiled_parser.rb'
+  file example_file => 'lib/kpeg/code_generator.rb'
+  file example_file => 'lib/kpeg/position.rb'
+  file example_file => example_file.sub(/\.rb$/, '')
+end
+
 desc "build the parser"
 task :parser => PARSER_FILES
+
+desc "build the examples"
+task :examples => EXAMPLE_FILES
+
+task :test => :examples
 
 task :gem do
   sh "gem build"

--- a/examples/calculator/calculator.kpeg.rb
+++ b/examples/calculator/calculator.kpeg.rb
@@ -53,6 +53,9 @@ class Calculator
       def current_line(target=pos)
         if line = position_line_offsets.bsearch_index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
         raise "Target position #{target} is outside of string"
       end
@@ -60,17 +63,22 @@ class Calculator
       def current_line(target=pos)
         if line = position_line_offsets.index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
-
         raise "Target position #{target} is outside of string"
       end
     end
 
     def current_character(target=pos)
-      if target < 0 || target >= string.size
+      if target < 0 || target > string.size
         raise "Target position #{target} is outside of string"
+      elsif target == string.size
+        ""
+      else
+        string[target, 1]
       end
-      string[target, 1]
     end
 
     KpegPosInfo = Struct.new(:pos, :lno, :col, :line, :char)

--- a/examples/calculator/calculator.kpeg.rb
+++ b/examples/calculator/calculator.kpeg.rb
@@ -1,4 +1,4 @@
-class LuaString
+class Calculator
   # :stopdoc:
 
     # This is distinct from setup_parser so that a standalone parser
@@ -396,17 +396,31 @@ class LuaString
   # :stopdoc:
   def setup_foreign_grammar; end
 
-  # equals = < "="* > { text }
-  def _equals
+  # space = " "
+  def _space
+    _tmp = match_string(" ")
+    set_failed_rule :_space unless _tmp
+    return _tmp
+  end
+
+  # - = space*
+  def __hyphen_
+    while true
+      _tmp = apply(:_space)
+      break unless _tmp
+    end
+    _tmp = true
+    set_failed_rule :__hyphen_ unless _tmp
+    return _tmp
+  end
+
+  # num = < /[1-9][0-9]*/ > { text.to_i }
+  def _num
 
     _save = self.pos
     while true # sequence
       _text_start = self.pos
-      while true
-        _tmp = match_string("=")
-        break unless _tmp
-      end
-      _tmp = true
+      _tmp = scan(/\G(?-mix:[1-9][0-9]*)/)
       if _tmp
         text = get_text(_text_start)
       end
@@ -414,7 +428,7 @@ class LuaString
         self.pos = _save
         break
       end
-      @result = begin;  text ; end
+      @result = begin;  text.to_i ; end
       _tmp = true
       unless _tmp
         self.pos = _save
@@ -422,103 +436,212 @@ class LuaString
       break
     end # end sequence
 
-    set_failed_rule :_equals unless _tmp
+    set_failed_rule :_num unless _tmp
     return _tmp
   end
 
-  # equal_ending = "]" equals:x &{ x == start } "]"
-  def _equal_ending(start)
+  # term = (term:t1 - "+" - term:t2 { t1 + t2 } | term:t1 - "-" - term:t2 { t1 - t2 } | fact)
+  def _term
 
     _save = self.pos
-    while true # sequence
-      _tmp = match_string("]")
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = apply(:_equals)
-      x = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save1 = self.pos
-      _tmp = begin;  x == start ; end
-      self.pos = _save1
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = match_string("]")
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
+    while true # choice
 
-    set_failed_rule :_equal_ending unless _tmp
+      _save1 = self.pos
+      while true # sequence
+        _tmp = apply(:_term)
+        t1 = @result
+        unless _tmp
+          self.pos = _save1
+          break
+        end
+        _tmp = apply(:__hyphen_)
+        unless _tmp
+          self.pos = _save1
+          break
+        end
+        _tmp = match_string("+")
+        unless _tmp
+          self.pos = _save1
+          break
+        end
+        _tmp = apply(:__hyphen_)
+        unless _tmp
+          self.pos = _save1
+          break
+        end
+        _tmp = apply(:_term)
+        t2 = @result
+        unless _tmp
+          self.pos = _save1
+          break
+        end
+        @result = begin;  t1 + t2 ; end
+        _tmp = true
+        unless _tmp
+          self.pos = _save1
+        end
+        break
+      end # end sequence
+
+      break if _tmp
+      self.pos = _save
+
+      _save2 = self.pos
+      while true # sequence
+        _tmp = apply(:_term)
+        t1 = @result
+        unless _tmp
+          self.pos = _save2
+          break
+        end
+        _tmp = apply(:__hyphen_)
+        unless _tmp
+          self.pos = _save2
+          break
+        end
+        _tmp = match_string("-")
+        unless _tmp
+          self.pos = _save2
+          break
+        end
+        _tmp = apply(:__hyphen_)
+        unless _tmp
+          self.pos = _save2
+          break
+        end
+        _tmp = apply(:_term)
+        t2 = @result
+        unless _tmp
+          self.pos = _save2
+          break
+        end
+        @result = begin;  t1 - t2 ; end
+        _tmp = true
+        unless _tmp
+          self.pos = _save2
+        end
+        break
+      end # end sequence
+
+      break if _tmp
+      self.pos = _save
+      _tmp = apply(:_fact)
+      break if _tmp
+      self.pos = _save
+      break
+    end # end choice
+
+    set_failed_rule :_term unless _tmp
     return _tmp
   end
 
-  # root = "[" equals:e "[" < (!equal_ending(e) .)* > equal_ending(e) {          @result = text        }
+  # fact = (fact:f1 - "*" - fact:f2 { f1 * f2 } | fact:f1 - "/" - fact:f2 { f1 / f2 } | num)
+  def _fact
+
+    _save = self.pos
+    while true # choice
+
+      _save1 = self.pos
+      while true # sequence
+        _tmp = apply(:_fact)
+        f1 = @result
+        unless _tmp
+          self.pos = _save1
+          break
+        end
+        _tmp = apply(:__hyphen_)
+        unless _tmp
+          self.pos = _save1
+          break
+        end
+        _tmp = match_string("*")
+        unless _tmp
+          self.pos = _save1
+          break
+        end
+        _tmp = apply(:__hyphen_)
+        unless _tmp
+          self.pos = _save1
+          break
+        end
+        _tmp = apply(:_fact)
+        f2 = @result
+        unless _tmp
+          self.pos = _save1
+          break
+        end
+        @result = begin;  f1 * f2 ; end
+        _tmp = true
+        unless _tmp
+          self.pos = _save1
+        end
+        break
+      end # end sequence
+
+      break if _tmp
+      self.pos = _save
+
+      _save2 = self.pos
+      while true # sequence
+        _tmp = apply(:_fact)
+        f1 = @result
+        unless _tmp
+          self.pos = _save2
+          break
+        end
+        _tmp = apply(:__hyphen_)
+        unless _tmp
+          self.pos = _save2
+          break
+        end
+        _tmp = match_string("/")
+        unless _tmp
+          self.pos = _save2
+          break
+        end
+        _tmp = apply(:__hyphen_)
+        unless _tmp
+          self.pos = _save2
+          break
+        end
+        _tmp = apply(:_fact)
+        f2 = @result
+        unless _tmp
+          self.pos = _save2
+          break
+        end
+        @result = begin;  f1 / f2 ; end
+        _tmp = true
+        unless _tmp
+          self.pos = _save2
+        end
+        break
+      end # end sequence
+
+      break if _tmp
+      self.pos = _save
+      _tmp = apply(:_num)
+      break if _tmp
+      self.pos = _save
+      break
+    end # end choice
+
+    set_failed_rule :_fact unless _tmp
+    return _tmp
+  end
+
+  # root = term:t { @result = t }
   def _root
 
     _save = self.pos
     while true # sequence
-      _tmp = match_string("[")
+      _tmp = apply(:_term)
+      t = @result
       unless _tmp
         self.pos = _save
         break
       end
-      _tmp = apply(:_equals)
-      e = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = match_string("[")
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _text_start = self.pos
-      while true
-
-        _save2 = self.pos
-        while true # sequence
-          _save3 = self.pos
-          _tmp = apply_with_args(:_equal_ending, e)
-          _tmp = _tmp ? nil : true
-          self.pos = _save3
-          unless _tmp
-            self.pos = _save2
-            break
-          end
-          _tmp = get_byte
-          unless _tmp
-            self.pos = _save2
-          end
-          break
-        end # end sequence
-
-        break unless _tmp
-      end
-      _tmp = true
-      if _tmp
-        text = get_text(_text_start)
-      end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = apply_with_args(:_equal_ending, e)
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin; 
-         @result = text
-       ; end
+      @result = begin;  @result = t ; end
       _tmp = true
       unless _tmp
         self.pos = _save
@@ -531,8 +654,11 @@ class LuaString
   end
 
   Rules = {}
-  Rules[:_equals] = rule_info("equals", "< \"=\"* > { text }")
-  Rules[:_equal_ending] = rule_info("equal_ending", "\"]\" equals:x &{ x == start } \"]\"")
-  Rules[:_root] = rule_info("root", "\"[\" equals:e \"[\" < (!equal_ending(e) .)* > equal_ending(e) {          @result = text        }")
+  Rules[:_space] = rule_info("space", "\" \"")
+  Rules[:__hyphen_] = rule_info("-", "space*")
+  Rules[:_num] = rule_info("num", "< /[1-9][0-9]*/ > { text.to_i }")
+  Rules[:_term] = rule_info("term", "(term:t1 - \"+\" - term:t2 { t1 + t2 } | term:t1 - \"-\" - term:t2 { t1 - t2 } | fact)")
+  Rules[:_fact] = rule_info("fact", "(fact:f1 - \"*\" - fact:f2 { f1 * f2 } | fact:f1 - \"/\" - fact:f2 { f1 / f2 } | num)")
+  Rules[:_root] = rule_info("root", "term:t { @result = t }")
   # :startdoc:
 end

--- a/examples/foreign_reference/literals.kpeg.rb
+++ b/examples/foreign_reference/literals.kpeg.rb
@@ -1,4 +1,4 @@
-class LuaString
+class Literal
   # :stopdoc:
 
     # This is distinct from setup_parser so that a standalone parser
@@ -388,151 +388,33 @@ class LuaString
 
 
   # :startdoc:
-
-
-  attr_accessor :result
-
-
   # :stopdoc:
   def setup_foreign_grammar; end
 
-  # equals = < "="* > { text }
-  def _equals
-
-    _save = self.pos
-    while true # sequence
-      _text_start = self.pos
-      while true
-        _tmp = match_string("=")
-        break unless _tmp
-      end
-      _tmp = true
-      if _tmp
-        text = get_text(_text_start)
-      end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  text ; end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_equals unless _tmp
+  # period = "."
+  def _period
+    _tmp = match_string(".")
+    set_failed_rule :_period unless _tmp
     return _tmp
   end
 
-  # equal_ending = "]" equals:x &{ x == start } "]"
-  def _equal_ending(start)
-
-    _save = self.pos
-    while true # sequence
-      _tmp = match_string("]")
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = apply(:_equals)
-      x = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save1 = self.pos
-      _tmp = begin;  x == start ; end
-      self.pos = _save1
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = match_string("]")
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_equal_ending unless _tmp
+  # space = " "
+  def _space
+    _tmp = match_string(" ")
+    set_failed_rule :_space unless _tmp
     return _tmp
   end
 
-  # root = "[" equals:e "[" < (!equal_ending(e) .)* > equal_ending(e) {          @result = text        }
-  def _root
-
-    _save = self.pos
-    while true # sequence
-      _tmp = match_string("[")
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = apply(:_equals)
-      e = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = match_string("[")
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _text_start = self.pos
-      while true
-
-        _save2 = self.pos
-        while true # sequence
-          _save3 = self.pos
-          _tmp = apply_with_args(:_equal_ending, e)
-          _tmp = _tmp ? nil : true
-          self.pos = _save3
-          unless _tmp
-            self.pos = _save2
-            break
-          end
-          _tmp = get_byte
-          unless _tmp
-            self.pos = _save2
-          end
-          break
-        end # end sequence
-
-        break unless _tmp
-      end
-      _tmp = true
-      if _tmp
-        text = get_text(_text_start)
-      end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = apply_with_args(:_equal_ending, e)
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin; 
-         @result = text
-       ; end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_root unless _tmp
+  # alpha = /[A-Za-z]/
+  def _alpha
+    _tmp = scan(/\G(?-mix:[A-Za-z])/)
+    set_failed_rule :_alpha unless _tmp
     return _tmp
   end
 
   Rules = {}
-  Rules[:_equals] = rule_info("equals", "< \"=\"* > { text }")
-  Rules[:_equal_ending] = rule_info("equal_ending", "\"]\" equals:x &{ x == start } \"]\"")
-  Rules[:_root] = rule_info("root", "\"[\" equals:e \"[\" < (!equal_ending(e) .)* > equal_ending(e) {          @result = text        }")
+  Rules[:_period] = rule_info("period", "\".\"")
+  Rules[:_space] = rule_info("space", "\" \"")
+  Rules[:_alpha] = rule_info("alpha", "/[A-Za-z]/")
   # :startdoc:
 end

--- a/examples/foreign_reference/literals.kpeg.rb
+++ b/examples/foreign_reference/literals.kpeg.rb
@@ -53,6 +53,9 @@ class Literal
       def current_line(target=pos)
         if line = position_line_offsets.bsearch_index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
         raise "Target position #{target} is outside of string"
       end
@@ -60,17 +63,22 @@ class Literal
       def current_line(target=pos)
         if line = position_line_offsets.index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
-
         raise "Target position #{target} is outside of string"
       end
     end
 
     def current_character(target=pos)
-      if target < 0 || target >= string.size
+      if target < 0 || target > string.size
         raise "Target position #{target} is outside of string"
+      elsif target == string.size
+        ""
+      else
+        string[target, 1]
       end
-      string[target, 1]
     end
 
     KpegPosInfo = Struct.new(:pos, :lno, :col, :line, :char)

--- a/examples/foreign_reference/matcher.kpeg.rb
+++ b/examples/foreign_reference/matcher.kpeg.rb
@@ -53,6 +53,9 @@ class Matcher
       def current_line(target=pos)
         if line = position_line_offsets.bsearch_index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
         raise "Target position #{target} is outside of string"
       end
@@ -60,17 +63,22 @@ class Matcher
       def current_line(target=pos)
         if line = position_line_offsets.index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
-
         raise "Target position #{target} is outside of string"
       end
     end
 
     def current_character(target=pos)
-      if target < 0 || target >= string.size
+      if target < 0 || target > string.size
         raise "Target position #{target} is outside of string"
+      elsif target == string.size
+        ""
+      else
+        string[target, 1]
       end
-      string[target, 1]
     end
 
     KpegPosInfo = Struct.new(:pos, :lno, :col, :line, :char)

--- a/examples/foreign_reference/matcher.kpeg.rb
+++ b/examples/foreign_reference/matcher.kpeg.rb
@@ -1,4 +1,4 @@
-class LuaString
+class Matcher
   # :stopdoc:
 
     # This is distinct from setup_parser so that a standalone parser
@@ -390,136 +390,71 @@ class LuaString
   # :startdoc:
 
 
-  attr_accessor :result
+	require "literals.kpeg.rb"
 
 
   # :stopdoc:
-  def setup_foreign_grammar; end
-
-  # equals = < "="* > { text }
-  def _equals
-
-    _save = self.pos
-    while true # sequence
-      _text_start = self.pos
-      while true
-        _tmp = match_string("=")
-        break unless _tmp
-      end
-      _tmp = true
-      if _tmp
-        text = get_text(_text_start)
-      end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  text ; end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_equals unless _tmp
-    return _tmp
+  def setup_foreign_grammar
+    @_grammar_grammer1 = Literal.new(nil)
   end
 
-  # equal_ending = "]" equals:x &{ x == start } "]"
-  def _equal_ending(start)
-
-    _save = self.pos
-    while true # sequence
-      _tmp = match_string("]")
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = apply(:_equals)
-      x = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save1 = self.pos
-      _tmp = begin;  x == start ; end
-      self.pos = _save1
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = match_string("]")
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_equal_ending unless _tmp
-    return _tmp
-  end
-
-  # root = "[" equals:e "[" < (!equal_ending(e) .)* > equal_ending(e) {          @result = text        }
+  # root = (%grammer1.alpha %grammer1.space*)+ %grammer1.period
   def _root
 
     _save = self.pos
     while true # sequence
-      _tmp = match_string("[")
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = apply(:_equals)
-      e = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = match_string("[")
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _text_start = self.pos
-      while true
+      _save1 = self.pos
 
-        _save2 = self.pos
-        while true # sequence
-          _save3 = self.pos
-          _tmp = apply_with_args(:_equal_ending, e)
-          _tmp = _tmp ? nil : true
-          self.pos = _save3
-          unless _tmp
-            self.pos = _save2
-            break
-          end
-          _tmp = get_byte
-          unless _tmp
-            self.pos = _save2
-          end
+      _save2 = self.pos
+      while true # sequence
+        _tmp = @_grammar_grammer1.external_invoke(self, :_alpha)
+        unless _tmp
+          self.pos = _save2
           break
-        end # end sequence
+        end
+        while true
+          _tmp = @_grammar_grammer1.external_invoke(self, :_space)
+          break unless _tmp
+        end
+        _tmp = true
+        unless _tmp
+          self.pos = _save2
+        end
+        break
+      end # end sequence
 
-        break unless _tmp
-      end
-      _tmp = true
       if _tmp
-        text = get_text(_text_start)
+        while true
+
+          _save4 = self.pos
+          while true # sequence
+            _tmp = @_grammar_grammer1.external_invoke(self, :_alpha)
+            unless _tmp
+              self.pos = _save4
+              break
+            end
+            while true
+              _tmp = @_grammar_grammer1.external_invoke(self, :_space)
+              break unless _tmp
+            end
+            _tmp = true
+            unless _tmp
+              self.pos = _save4
+            end
+            break
+          end # end sequence
+
+          break unless _tmp
+        end
+        _tmp = true
+      else
+        self.pos = _save1
       end
       unless _tmp
         self.pos = _save
         break
       end
-      _tmp = apply_with_args(:_equal_ending, e)
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin; 
-         @result = text
-       ; end
-      _tmp = true
+      _tmp = @_grammar_grammer1.external_invoke(self, :_period)
       unless _tmp
         self.pos = _save
       end
@@ -531,8 +466,6 @@ class LuaString
   end
 
   Rules = {}
-  Rules[:_equals] = rule_info("equals", "< \"=\"* > { text }")
-  Rules[:_equal_ending] = rule_info("equal_ending", "\"]\" equals:x &{ x == start } \"]\"")
-  Rules[:_root] = rule_info("root", "\"[\" equals:e \"[\" < (!equal_ending(e) .)* > equal_ending(e) {          @result = text        }")
+  Rules[:_root] = rule_info("root", "(%grammer1.alpha %grammer1.space*)+ %grammer1.period")
   # :startdoc:
 end

--- a/examples/lua_string/lua_string.kpeg.rb
+++ b/examples/lua_string/lua_string.kpeg.rb
@@ -53,6 +53,9 @@ class LuaString
       def current_line(target=pos)
         if line = position_line_offsets.bsearch_index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
         raise "Target position #{target} is outside of string"
       end
@@ -60,17 +63,22 @@ class LuaString
       def current_line(target=pos)
         if line = position_line_offsets.index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
-
         raise "Target position #{target} is outside of string"
       end
     end
 
     def current_character(target=pos)
-      if target < 0 || target >= string.size
+      if target < 0 || target > string.size
         raise "Target position #{target} is outside of string"
+      elsif target == string.size
+        ""
+      else
+        string[target, 1]
       end
-      string[target, 1]
     end
 
     KpegPosInfo = Struct.new(:pos, :lno, :col, :line, :char)

--- a/examples/phone_number/phone_number.kpeg.rb
+++ b/examples/phone_number/phone_number.kpeg.rb
@@ -53,6 +53,9 @@ class PhoneNumber
       def current_line(target=pos)
         if line = position_line_offsets.bsearch_index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
         raise "Target position #{target} is outside of string"
       end
@@ -60,17 +63,22 @@ class PhoneNumber
       def current_line(target=pos)
         if line = position_line_offsets.index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
-
         raise "Target position #{target} is outside of string"
       end
     end
 
     def current_character(target=pos)
-      if target < 0 || target >= string.size
+      if target < 0 || target > string.size
         raise "Target position #{target} is outside of string"
+      elsif target == string.size
+        ""
+      else
+        string[target, 1]
       end
-      string[target, 1]
     end
 
     KpegPosInfo = Struct.new(:pos, :lno, :col, :line, :char)

--- a/examples/tiny_markdown/tiny_markdown.kpeg.rb
+++ b/examples/tiny_markdown/tiny_markdown.kpeg.rb
@@ -18,6 +18,7 @@ class TinyMarkdown::Parser
       @result = nil
       @failed_rule = nil
       @failing_rule_offset = -1
+      @line_offsets = nil
 
       setup_foreign_grammar
     end
@@ -27,30 +28,75 @@ class TinyMarkdown::Parser
     attr_accessor :result, :pos
 
     def current_column(target=pos)
-      if c = string.rindex("\n", target-1)
-        return target - c - 1
+      if string[target] == "\n" && (c = string.rindex("\n", target-1) || -1)
+        return target - c
+      elsif c = string.rindex("\n", target)
+        return target - c
       end
 
       target + 1
     end
 
-    def current_line(target=pos)
-      cur_offset = 0
-      cur_line = 0
-
-      string.each_line do |line|
-        cur_line += 1
-        cur_offset += line.size
-        return cur_line if cur_offset >= target
+    def position_line_offsets
+      unless @position_line_offsets
+        @position_line_offsets = []
+        total = 0
+        string.each_line do |line|
+          total += line.size
+          @position_line_offsets << total
+        end
       end
+      @position_line_offsets
+    end
 
-      -1
+    if [].respond_to? :bsearch_index
+      def current_line(target=pos)
+        if line = position_line_offsets.bsearch_index {|x| x > target }
+          return line + 1
+        end
+        raise "Target position #{target} is outside of string"
+      end
+    else
+      def current_line(target=pos)
+        if line = position_line_offsets.index {|x| x > target }
+          return line + 1
+        end
+
+        raise "Target position #{target} is outside of string"
+      end
+    end
+
+    def current_character(target=pos)
+      if target < 0 || target >= string.size
+        raise "Target position #{target} is outside of string"
+      end
+      string[target, 1]
+    end
+
+    KpegPosInfo = Struct.new(:pos, :lno, :col, :line, :char)
+
+    def current_pos_info(target=pos)
+      l = current_line target
+      c = current_column target
+      ln = get_line(l-1)
+      chr = string[target,1]
+      KpegPosInfo.new(target, l, c, ln, chr)
     end
 
     def lines
-      lines = []
-      string.each_line { |l| lines << l }
-      lines
+      string.lines
+    end
+
+    def get_line(no)
+      loff = position_line_offsets
+      if no < 0
+        raise "Line No is out of range: #{no} < 0"
+      elsif no >= loff.size
+        raise "Line No is out of range: #{no} >= #{loff.size}"
+      end
+      lend = loff[no]-1
+      lstart = no > 0 ? loff[no-1] : 0
+      string[lstart..lend]
     end
 
 
@@ -64,6 +110,7 @@ class TinyMarkdown::Parser
       @string = string
       @string_size = string ? string.size : 0
       @pos = pos
+      @position_line_offsets = nil
     end
 
     def show_pos
@@ -88,30 +135,22 @@ class TinyMarkdown::Parser
     end
 
     def failure_caret
-      l = current_line @failing_rule_offset
-      c = current_column @failing_rule_offset
-
-      line = lines[l-1]
-      "#{line}\n#{' ' * (c - 1)}^"
+      p = current_pos_info @failing_rule_offset
+      "#{p.line.chomp}\n#{' ' * (p.col - 1)}^"
     end
 
     def failure_character
-      l = current_line @failing_rule_offset
-      c = current_column @failing_rule_offset
-      lines[l-1][c-1, 1]
+      current_character @failing_rule_offset
     end
 
     def failure_oneline
-      l = current_line @failing_rule_offset
-      c = current_column @failing_rule_offset
-
-      char = lines[l-1][c-1, 1]
+      p = current_pos_info @failing_rule_offset
 
       if @failed_rule.kind_of? Symbol
         info = self.class::Rules[@failed_rule]
-        "@#{l}:#{c} failed rule '#{info.name}', got '#{char}'"
+        "@#{p.lno}:#{p.col} failed rule '#{info.name}', got '#{p.char}'"
       else
-        "@#{l}:#{c} failed rule '#{@failed_rule}', got '#{char}'"
+        "@#{p.lno}:#{p.col} failed rule '#{@failed_rule}', got '#{p.char}'"
       end
     end
 
@@ -124,10 +163,9 @@ class TinyMarkdown::Parser
 
     def show_error(io=STDOUT)
       error_pos = @failing_rule_offset
-      line_no = current_line(error_pos)
-      col_no = current_column(error_pos)
+      p = current_pos_info(error_pos)
 
-      io.puts "On line #{line_no}, column #{col_no}:"
+      io.puts "On line #{p.lno}, column #{p.col}:"
 
       if @failed_rule.kind_of? Symbol
         info = self.class::Rules[@failed_rule]
@@ -136,10 +174,9 @@ class TinyMarkdown::Parser
         io.puts "Failed to match rule '#{@failed_rule}'"
       end
 
-      io.puts "Got: #{string[error_pos,1].inspect}"
-      line = lines[line_no-1]
-      io.puts "=> #{line}"
-      io.print(" " * (col_no + 3))
+      io.puts "Got: #{p.char.inspect}"
+      io.puts "=> #{p.line}"
+      io.print(" " * (p.col + 2))
       io.puts "^"
     end
 
@@ -163,9 +200,8 @@ class TinyMarkdown::Parser
     end
 
     def scan(reg)
-      if m = reg.match(@string[@pos..-1])
-        width = m.end(0)
-        @pos += width
+      if m = reg.match(@string, @pos)
+        @pos = m.end(0)
         return true
       end
 
@@ -249,6 +285,7 @@ class TinyMarkdown::Parser
     end
 
     def apply_with_args(rule, *args)
+      @result = nil
       memo_key = [rule, args]
       if m = @memoizations[memo_key][@pos]
         @pos = m.pos
@@ -278,12 +315,11 @@ class TinyMarkdown::Parser
         else
           return ans
         end
-
-        return ans
       end
     end
 
     def apply(rule)
+      @result = nil
       if m = @memoizations[rule][@pos]
         @pos = m.pos
         if !m.set
@@ -312,8 +348,6 @@ class TinyMarkdown::Parser
         else
           return ans
         end
-
-        return ans
       end
     end
 
@@ -808,7 +842,7 @@ class TinyMarkdown::Parser
     _save = self.pos
     while true # sequence
       _text_start = self.pos
-      _tmp = scan(/\A(?-mix:######|#####|####|###|##|#)/)
+      _tmp = scan(/\G(?-mix:######|#####|####|###|##|#)/)
       if _tmp
         text = get_text(_text_start)
       end
@@ -2941,7 +2975,7 @@ class TinyMarkdown::Parser
     _save = self.pos
     while true # sequence
       _text_start = self.pos
-      _tmp = scan(/\A(?-mix:`)/)
+      _tmp = scan(/\G(?-mix:`)/)
       if _tmp
         text = get_text(_text_start)
       end
@@ -2975,7 +3009,7 @@ class TinyMarkdown::Parser
     _save = self.pos
     while true # sequence
       _text_start = self.pos
-      _tmp = scan(/\A(?-mix:``)/)
+      _tmp = scan(/\G(?-mix:``)/)
       if _tmp
         text = get_text(_text_start)
       end
@@ -3340,7 +3374,7 @@ class TinyMarkdown::Parser
     _save = self.pos
     while true # sequence
       _text_start = self.pos
-      _tmp = scan(/\A(?-mix: |\t)/)
+      _tmp = scan(/\G(?-mix: |\t)/)
       if _tmp
         text = get_text(_text_start)
       end
@@ -3496,7 +3530,7 @@ class TinyMarkdown::Parser
     _save = self.pos
     while true # sequence
       _text_start = self.pos
-      _tmp = scan(/\A(?-mix:[~*_`&\[\]()<!#\\'"])/)
+      _tmp = scan(/\G(?-mix:[~*_`&\[\]()<!#\\'"])/)
       if _tmp
         text = get_text(_text_start)
       end
@@ -3570,7 +3604,7 @@ class TinyMarkdown::Parser
     _save = self.pos
     while true # sequence
       _text_start = self.pos
-      _tmp = scan(/\A(?-mix:[A-Za-z0-9])/)
+      _tmp = scan(/\G(?-mix:[A-Za-z0-9])/)
       if _tmp
         text = get_text(_text_start)
       end
@@ -3596,7 +3630,7 @@ class TinyMarkdown::Parser
     _save = self.pos
     while true # sequence
       _text_start = self.pos
-      _tmp = scan(/\A(?-mix:[0-9])/)
+      _tmp = scan(/\G(?-mix:[0-9])/)
       if _tmp
         text = get_text(_text_start)
       end
@@ -3622,7 +3656,7 @@ class TinyMarkdown::Parser
     _save = self.pos
     while true # sequence
       _text_start = self.pos
-      _tmp = scan(/\A(?-mix:   |  | |)/)
+      _tmp = scan(/\G(?-mix:   |  | |)/)
       if _tmp
         text = get_text(_text_start)
       end
@@ -3648,7 +3682,7 @@ class TinyMarkdown::Parser
     _save = self.pos
     while true # sequence
       _text_start = self.pos
-      _tmp = scan(/\A(?-mix:\t|    )/)
+      _tmp = scan(/\G(?-mix:\t|    )/)
       if _tmp
         text = get_text(_text_start)
       end
@@ -3757,7 +3791,7 @@ class TinyMarkdown::Parser
         _save2 = self.pos
         while true # sequence
           _text_start = self.pos
-          _tmp = scan(/\A(?-mix:[^\r\n]*)/)
+          _tmp = scan(/\G(?-mix:[^\r\n]*)/)
           if _tmp
             text = get_text(_text_start)
           end
@@ -3784,7 +3818,7 @@ class TinyMarkdown::Parser
         _save3 = self.pos
         while true # sequence
           _text_start = self.pos
-          _tmp = scan(/\A(?-mix:.+)/)
+          _tmp = scan(/\G(?-mix:.+)/)
           if _tmp
             text = get_text(_text_start)
           end

--- a/examples/tiny_markdown/tiny_markdown.kpeg.rb
+++ b/examples/tiny_markdown/tiny_markdown.kpeg.rb
@@ -53,6 +53,9 @@ class TinyMarkdown::Parser
       def current_line(target=pos)
         if line = position_line_offsets.bsearch_index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
         raise "Target position #{target} is outside of string"
       end
@@ -60,17 +63,22 @@ class TinyMarkdown::Parser
       def current_line(target=pos)
         if line = position_line_offsets.index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
-
         raise "Target position #{target} is outside of string"
       end
     end
 
     def current_character(target=pos)
-      if target < 0 || target >= string.size
+      if target < 0 || target > string.size
         raise "Target position #{target} is outside of string"
+      elsif target == string.size
+        ""
+      else
+        string[target, 1]
       end
-      string[target, 1]
     end
 
     KpegPosInfo = Struct.new(:pos, :lno, :col, :line, :char)

--- a/examples/upper/upper.kpeg.rb
+++ b/examples/upper/upper.kpeg.rb
@@ -53,6 +53,9 @@ class Upper
       def current_line(target=pos)
         if line = position_line_offsets.bsearch_index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
         raise "Target position #{target} is outside of string"
       end
@@ -60,17 +63,22 @@ class Upper
       def current_line(target=pos)
         if line = position_line_offsets.index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
-
         raise "Target position #{target} is outside of string"
       end
     end
 
     def current_character(target=pos)
-      if target < 0 || target >= string.size
+      if target < 0 || target > string.size
         raise "Target position #{target} is outside of string"
+      elsif target == string.size
+        ""
+      else
+        string[target, 1]
       end
-      string[target, 1]
     end
 
     KpegPosInfo = Struct.new(:pos, :lno, :col, :line, :char)

--- a/examples/upper/upper.kpeg.rb
+++ b/examples/upper/upper.kpeg.rb
@@ -1,4 +1,4 @@
-class LuaString
+class Upper
   # :stopdoc:
 
     # This is distinct from setup_parser so that a standalone parser
@@ -390,23 +390,33 @@ class LuaString
   # :startdoc:
 
 
-  attr_accessor :result
+    attr_accessor :output
 
 
   # :stopdoc:
   def setup_foreign_grammar; end
 
-  # equals = < "="* > { text }
-  def _equals
+  # period = "."
+  def _period
+    _tmp = match_string(".")
+    set_failed_rule :_period unless _tmp
+    return _tmp
+  end
+
+  # space = " "
+  def _space
+    _tmp = match_string(" ")
+    set_failed_rule :_space unless _tmp
+    return _tmp
+  end
+
+  # alpha = < /[A-Za-z]/ > { text.upcase }
+  def _alpha
 
     _save = self.pos
     while true # sequence
       _text_start = self.pos
-      while true
-        _tmp = match_string("=")
-        break unless _tmp
-      end
-      _tmp = true
+      _tmp = scan(/\G(?-mix:[A-Za-z])/)
       if _tmp
         text = get_text(_text_start)
       end
@@ -414,7 +424,7 @@ class LuaString
         self.pos = _save
         break
       end
-      @result = begin;  text ; end
+      @result = begin;  text.upcase ; end
       _tmp = true
       unless _tmp
         self.pos = _save
@@ -422,103 +432,252 @@ class LuaString
       break
     end # end sequence
 
-    set_failed_rule :_equals unless _tmp
+    set_failed_rule :_alpha unless _tmp
     return _tmp
   end
 
-  # equal_ending = "]" equals:x &{ x == start } "]"
-  def _equal_ending(start)
+  # word = (alpha:a word:w { "#{a}#{w}" } | alpha:a space { "#{a} "} | alpha:a { a })
+  def _word
 
     _save = self.pos
-    while true # sequence
-      _tmp = match_string("]")
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = apply(:_equals)
-      x = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save1 = self.pos
-      _tmp = begin;  x == start ; end
-      self.pos = _save1
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = match_string("]")
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
+    while true # choice
 
-    set_failed_rule :_equal_ending unless _tmp
+      _save1 = self.pos
+      while true # sequence
+        _tmp = apply(:_alpha)
+        a = @result
+        unless _tmp
+          self.pos = _save1
+          break
+        end
+        _tmp = apply(:_word)
+        w = @result
+        unless _tmp
+          self.pos = _save1
+          break
+        end
+        @result = begin;  "#{a}#{w}" ; end
+        _tmp = true
+        unless _tmp
+          self.pos = _save1
+        end
+        break
+      end # end sequence
+
+      break if _tmp
+      self.pos = _save
+
+      _save2 = self.pos
+      while true # sequence
+        _tmp = apply(:_alpha)
+        a = @result
+        unless _tmp
+          self.pos = _save2
+          break
+        end
+        _tmp = apply(:_space)
+        unless _tmp
+          self.pos = _save2
+          break
+        end
+        @result = begin;  "#{a} "; end
+        _tmp = true
+        unless _tmp
+          self.pos = _save2
+        end
+        break
+      end # end sequence
+
+      break if _tmp
+      self.pos = _save
+
+      _save3 = self.pos
+      while true # sequence
+        _tmp = apply(:_alpha)
+        a = @result
+        unless _tmp
+          self.pos = _save3
+          break
+        end
+        @result = begin;  a ; end
+        _tmp = true
+        unless _tmp
+          self.pos = _save3
+        end
+        break
+      end # end sequence
+
+      break if _tmp
+      self.pos = _save
+      break
+    end # end choice
+
+    set_failed_rule :_word unless _tmp
     return _tmp
   end
 
-  # root = "[" equals:e "[" < (!equal_ending(e) .)* > equal_ending(e) {          @result = text        }
+  # sentence = (word:w sentence:s { "#{w}#{s}" } | word:w { w })
+  def _sentence
+
+    _save = self.pos
+    while true # choice
+
+      _save1 = self.pos
+      while true # sequence
+        _tmp = apply(:_word)
+        w = @result
+        unless _tmp
+          self.pos = _save1
+          break
+        end
+        _tmp = apply(:_sentence)
+        s = @result
+        unless _tmp
+          self.pos = _save1
+          break
+        end
+        @result = begin;  "#{w}#{s}" ; end
+        _tmp = true
+        unless _tmp
+          self.pos = _save1
+        end
+        break
+      end # end sequence
+
+      break if _tmp
+      self.pos = _save
+
+      _save2 = self.pos
+      while true # sequence
+        _tmp = apply(:_word)
+        w = @result
+        unless _tmp
+          self.pos = _save2
+          break
+        end
+        @result = begin;  w ; end
+        _tmp = true
+        unless _tmp
+          self.pos = _save2
+        end
+        break
+      end # end sequence
+
+      break if _tmp
+      self.pos = _save
+      break
+    end # end choice
+
+    set_failed_rule :_sentence unless _tmp
+    return _tmp
+  end
+
+  # document = (sentence:s period space* document:d { "#{s}. #{d}" } | sentence:s period { "#{s}." } | sentence:s { "#{s}" })
+  def _document
+
+    _save = self.pos
+    while true # choice
+
+      _save1 = self.pos
+      while true # sequence
+        _tmp = apply(:_sentence)
+        s = @result
+        unless _tmp
+          self.pos = _save1
+          break
+        end
+        _tmp = apply(:_period)
+        unless _tmp
+          self.pos = _save1
+          break
+        end
+        while true
+          _tmp = apply(:_space)
+          break unless _tmp
+        end
+        _tmp = true
+        unless _tmp
+          self.pos = _save1
+          break
+        end
+        _tmp = apply(:_document)
+        d = @result
+        unless _tmp
+          self.pos = _save1
+          break
+        end
+        @result = begin;  "#{s}. #{d}" ; end
+        _tmp = true
+        unless _tmp
+          self.pos = _save1
+        end
+        break
+      end # end sequence
+
+      break if _tmp
+      self.pos = _save
+
+      _save3 = self.pos
+      while true # sequence
+        _tmp = apply(:_sentence)
+        s = @result
+        unless _tmp
+          self.pos = _save3
+          break
+        end
+        _tmp = apply(:_period)
+        unless _tmp
+          self.pos = _save3
+          break
+        end
+        @result = begin;  "#{s}." ; end
+        _tmp = true
+        unless _tmp
+          self.pos = _save3
+        end
+        break
+      end # end sequence
+
+      break if _tmp
+      self.pos = _save
+
+      _save4 = self.pos
+      while true # sequence
+        _tmp = apply(:_sentence)
+        s = @result
+        unless _tmp
+          self.pos = _save4
+          break
+        end
+        @result = begin;  "#{s}" ; end
+        _tmp = true
+        unless _tmp
+          self.pos = _save4
+        end
+        break
+      end # end sequence
+
+      break if _tmp
+      self.pos = _save
+      break
+    end # end choice
+
+    set_failed_rule :_document unless _tmp
+    return _tmp
+  end
+
+  # root = document:d { @output = d }
   def _root
 
     _save = self.pos
     while true # sequence
-      _tmp = match_string("[")
+      _tmp = apply(:_document)
+      d = @result
       unless _tmp
         self.pos = _save
         break
       end
-      _tmp = apply(:_equals)
-      e = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = match_string("[")
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _text_start = self.pos
-      while true
-
-        _save2 = self.pos
-        while true # sequence
-          _save3 = self.pos
-          _tmp = apply_with_args(:_equal_ending, e)
-          _tmp = _tmp ? nil : true
-          self.pos = _save3
-          unless _tmp
-            self.pos = _save2
-            break
-          end
-          _tmp = get_byte
-          unless _tmp
-            self.pos = _save2
-          end
-          break
-        end # end sequence
-
-        break unless _tmp
-      end
-      _tmp = true
-      if _tmp
-        text = get_text(_text_start)
-      end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = apply_with_args(:_equal_ending, e)
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin; 
-         @result = text
-       ; end
+      @result = begin;  @output = d ; end
       _tmp = true
       unless _tmp
         self.pos = _save
@@ -531,8 +690,12 @@ class LuaString
   end
 
   Rules = {}
-  Rules[:_equals] = rule_info("equals", "< \"=\"* > { text }")
-  Rules[:_equal_ending] = rule_info("equal_ending", "\"]\" equals:x &{ x == start } \"]\"")
-  Rules[:_root] = rule_info("root", "\"[\" equals:e \"[\" < (!equal_ending(e) .)* > equal_ending(e) {          @result = text        }")
+  Rules[:_period] = rule_info("period", "\".\"")
+  Rules[:_space] = rule_info("space", "\" \"")
+  Rules[:_alpha] = rule_info("alpha", "< /[A-Za-z]/ > { text.upcase }")
+  Rules[:_word] = rule_info("word", "(alpha:a word:w { \"\#{a}\#{w}\" } | alpha:a space { \"\#{a} \"} | alpha:a { a })")
+  Rules[:_sentence] = rule_info("sentence", "(word:w sentence:s { \"\#{w}\#{s}\" } | word:w { w })")
+  Rules[:_document] = rule_info("document", "(sentence:s period space* document:d { \"\#{s}. \#{d}\" } | sentence:s period { \"\#{s}.\" } | sentence:s { \"\#{s}\" })")
+  Rules[:_root] = rule_info("root", "document:d { @output = d }")
   # :startdoc:
 end

--- a/lib/kpeg/format_parser.rb
+++ b/lib/kpeg/format_parser.rb
@@ -45,6 +45,9 @@ class KPeg::FormatParser
       def current_line(target=pos)
         if line = position_line_offsets.bsearch_index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
         raise "Target position #{target} is outside of string"
       end
@@ -52,17 +55,22 @@ class KPeg::FormatParser
       def current_line(target=pos)
         if line = position_line_offsets.index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
-
         raise "Target position #{target} is outside of string"
       end
     end
 
     def current_character(target=pos)
-      if target < 0 || target >= string.size
+      if target < 0 || target > string.size
         raise "Target position #{target} is outside of string"
+      elsif target == string.size
+        ""
+      else
+        string[target, 1]
       end
-      string[target, 1]
     end
 
     KpegPosInfo = Struct.new(:pos, :lno, :col, :line, :char)

--- a/lib/kpeg/position.rb
+++ b/lib/kpeg/position.rb
@@ -28,6 +28,9 @@ module KPeg
       def current_line(target=pos)
         if line = position_line_offsets.bsearch_index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
         raise "Target position #{target} is outside of string"
       end
@@ -35,17 +38,22 @@ module KPeg
       def current_line(target=pos)
         if line = position_line_offsets.index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
-
         raise "Target position #{target} is outside of string"
       end
     end
 
     def current_character(target=pos)
-      if target < 0 || target >= string.size
+      if target < 0 || target > string.size
         raise "Target position #{target} is outside of string"
+      elsif target == string.size
+        ""
+      else
+        string[target, 1]
       end
-      string[target, 1]
     end
 
     KpegPosInfo = Struct.new(:pos, :lno, :col, :line, :char)

--- a/lib/kpeg/string_escape.rb
+++ b/lib/kpeg/string_escape.rb
@@ -53,6 +53,9 @@ class KPeg::StringEscape
       def current_line(target=pos)
         if line = position_line_offsets.bsearch_index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
         raise "Target position #{target} is outside of string"
       end
@@ -60,17 +63,22 @@ class KPeg::StringEscape
       def current_line(target=pos)
         if line = position_line_offsets.index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
-
         raise "Target position #{target} is outside of string"
       end
     end
 
     def current_character(target=pos)
-      if target < 0 || target >= string.size
+      if target < 0 || target > string.size
         raise "Target position #{target} is outside of string"
+      elsif target == string.size
+        ""
+      else
+        string[target, 1]
       end
-      string[target, 1]
     end
 
     KpegPosInfo = Struct.new(:pos, :lno, :col, :line, :char)

--- a/test/test_kpeg_compiled_parser.rb
+++ b/test/test_kpeg_compiled_parser.rb
@@ -29,6 +29,12 @@ class TestKPegCompiledParser < Minitest::Test
 
   KPeg.compile gram, "ProdTestParser", self
 
+  gram = <<-GRAM
+  root = [a-z] "\n"
+  GRAM
+
+  KPeg.compile gram, "TestNLParser", self
+
   def test_current_column
     r = TestParser.new "hello\nsir\nand goodbye"
     assert_equal 1, r.current_column(0)
@@ -102,6 +108,24 @@ class TestKPegCompiledParser < Minitest::Test
 
     expected = "@1:1 failed rule 'letter', got '9'"
     assert_equal expected, r.failure_oneline
+  end
+
+  def test_position_at_the_end
+    r = TestParser.new "l"
+    assert r.parse, "should parse"
+
+    assert_equal 1, r.pos
+    assert_equal 1, r.current_line
+    assert_equal 2, r.current_column
+  end
+
+  def test_position_at_the_end_after_nl
+    r = TestNLParser.new "l\n"
+    assert r.parse, "should parse"
+
+    assert_equal 2, r.pos
+    assert_equal 2, r.current_line
+    assert_equal 1, r.current_column
   end
 
   def test_composite_grammar


### PR DESCRIPTION
tiny_markdown example fails otherwise

And refresh compilled examples.