### PR TITLE
Simplify generated code

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -23,20 +23,38 @@ rule ".rb" => ".kpeg" do |t|
   ruby "-Ilib bin/kpeg -s -o #{t.name} -f #{t.source}"
 end
 
+rule ".kpeg.rb" => ".kpeg" do |t|
+  ruby "-Ilib bin/kpeg -s -o #{t.name} -f #{t.source}"
+end
+
 PARSER_FILES = %w[
   lib/kpeg/string_escape.rb
   lib/kpeg/format_parser.rb
 ]
 
-PARSER_FILES.map do |parser_file|
+PARSER_FILES.each do |parser_file|
   file parser_file => 'lib/kpeg/compiled_parser.rb'
   file parser_file => 'lib/kpeg/code_generator.rb'
   file parser_file => 'lib/kpeg/position.rb'
   file parser_file => parser_file.sub(/\.rb$/, '.kpeg')
 end
 
+EXAMPLE_FILES = Dir.glob('examples/*/*.kpeg').map{|f| f + ".rb" }
+
+EXAMPLE_FILES.each do |example_file|
+  file example_file => 'lib/kpeg/compiled_parser.rb'
+  file example_file => 'lib/kpeg/code_generator.rb'
+  file example_file => 'lib/kpeg/position.rb'
+  file example_file => example_file.sub(/\.rb$/, '')
+end
+
 desc "build the parser"
 task :parser => PARSER_FILES
+
+desc "build the examples"
+task :examples => EXAMPLE_FILES
+
+task :test => :examples
 
 task :gem do
   sh "gem build"

--- a/examples/calculator/calculator.kpeg.rb
+++ b/examples/calculator/calculator.kpeg.rb
@@ -53,6 +53,9 @@ class Calculator
       def current_line(target=pos)
         if line = position_line_offsets.bsearch_index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
         raise "Target position #{target} is outside of string"
       end
@@ -60,17 +63,22 @@ class Calculator
       def current_line(target=pos)
         if line = position_line_offsets.index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
-
         raise "Target position #{target} is outside of string"
       end
     end
 
     def current_character(target=pos)
-      if target < 0 || target >= string.size
+      if target < 0 || target > string.size
         raise "Target position #{target} is outside of string"
+      elsif target == string.size
+        ""
+      else
+        string[target, 1]
       end
-      string[target, 1]
     end
 
     KpegPosInfo = Struct.new(:pos, :lno, :col, :line, :char)

--- a/examples/calculator/calculator.kpeg.rb
+++ b/examples/calculator/calculator.kpeg.rb
@@ -1,4 +1,4 @@
-class LuaString
+class Calculator
   # :stopdoc:
 
     # This is distinct from setup_parser so that a standalone parser
@@ -396,17 +396,31 @@ class LuaString
   # :stopdoc:
   def setup_foreign_grammar; end
 
-  # equals = < "="* > { text }
-  def _equals
+  # space = " "
+  def _space
+    _tmp = match_string(" ")
+    set_failed_rule :_space unless _tmp
+    return _tmp
+  end
+
+  # - = space*
+  def __hyphen_
+    while true
+      _tmp = apply(:_space)
+      break unless _tmp
+    end
+    _tmp = true
+    set_failed_rule :__hyphen_ unless _tmp
+    return _tmp
+  end
+
+  # num = < /[1-9][0-9]*/ > { text.to_i }
+  def _num
 
     _save = self.pos
     while true # sequence
       _text_start = self.pos
-      while true
-        _tmp = match_string("=")
-        break unless _tmp
-      end
-      _tmp = true
+      _tmp = scan(/\G(?-mix:[1-9][0-9]*)/)
       if _tmp
         text = get_text(_text_start)
       end
@@ -414,7 +428,7 @@ class LuaString
         self.pos = _save
         break
       end
-      @result = begin;  text ; end
+      @result = begin;  text.to_i ; end
       _tmp = true
       unless _tmp
         self.pos = _save
@@ -422,103 +436,212 @@ class LuaString
       break
     end # end sequence
 
-    set_failed_rule :_equals unless _tmp
+    set_failed_rule :_num unless _tmp
     return _tmp
   end
 
-  # equal_ending = "]" equals:x &{ x == start } "]"
-  def _equal_ending(start)
+  # term = (term:t1 - "+" - term:t2 { t1 + t2 } | term:t1 - "-" - term:t2 { t1 - t2 } | fact)
+  def _term
 
     _save = self.pos
-    while true # sequence
-      _tmp = match_string("]")
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = apply(:_equals)
-      x = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save1 = self.pos
-      _tmp = begin;  x == start ; end
-      self.pos = _save1
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = match_string("]")
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
+    while true # choice
 
-    set_failed_rule :_equal_ending unless _tmp
+      _save1 = self.pos
+      while true # sequence
+        _tmp = apply(:_term)
+        t1 = @result
+        unless _tmp
+          self.pos = _save1
+          break
+        end
+        _tmp = apply(:__hyphen_)
+        unless _tmp
+          self.pos = _save1
+          break
+        end
+        _tmp = match_string("+")
+        unless _tmp
+          self.pos = _save1
+          break
+        end
+        _tmp = apply(:__hyphen_)
+        unless _tmp
+          self.pos = _save1
+          break
+        end
+        _tmp = apply(:_term)
+        t2 = @result
+        unless _tmp
+          self.pos = _save1
+          break
+        end
+        @result = begin;  t1 + t2 ; end
+        _tmp = true
+        unless _tmp
+          self.pos = _save1
+        end
+        break
+      end # end sequence
+
+      break if _tmp
+      self.pos = _save
+
+      _save2 = self.pos
+      while true # sequence
+        _tmp = apply(:_term)
+        t1 = @result
+        unless _tmp
+          self.pos = _save2
+          break
+        end
+        _tmp = apply(:__hyphen_)
+        unless _tmp
+          self.pos = _save2
+          break
+        end
+        _tmp = match_string("-")
+        unless _tmp
+          self.pos = _save2
+          break
+        end
+        _tmp = apply(:__hyphen_)
+        unless _tmp
+          self.pos = _save2
+          break
+        end
+        _tmp = apply(:_term)
+        t2 = @result
+        unless _tmp
+          self.pos = _save2
+          break
+        end
+        @result = begin;  t1 - t2 ; end
+        _tmp = true
+        unless _tmp
+          self.pos = _save2
+        end
+        break
+      end # end sequence
+
+      break if _tmp
+      self.pos = _save
+      _tmp = apply(:_fact)
+      break if _tmp
+      self.pos = _save
+      break
+    end # end choice
+
+    set_failed_rule :_term unless _tmp
     return _tmp
   end
 
-  # root = "[" equals:e "[" < (!equal_ending(e) .)* > equal_ending(e) {          @result = text        }
+  # fact = (fact:f1 - "*" - fact:f2 { f1 * f2 } | fact:f1 - "/" - fact:f2 { f1 / f2 } | num)
+  def _fact
+
+    _save = self.pos
+    while true # choice
+
+      _save1 = self.pos
+      while true # sequence
+        _tmp = apply(:_fact)
+        f1 = @result
+        unless _tmp
+          self.pos = _save1
+          break
+        end
+        _tmp = apply(:__hyphen_)
+        unless _tmp
+          self.pos = _save1
+          break
+        end
+        _tmp = match_string("*")
+        unless _tmp
+          self.pos = _save1
+          break
+        end
+        _tmp = apply(:__hyphen_)
+        unless _tmp
+          self.pos = _save1
+          break
+        end
+        _tmp = apply(:_fact)
+        f2 = @result
+        unless _tmp
+          self.pos = _save1
+          break
+        end
+        @result = begin;  f1 * f2 ; end
+        _tmp = true
+        unless _tmp
+          self.pos = _save1
+        end
+        break
+      end # end sequence
+
+      break if _tmp
+      self.pos = _save
+
+      _save2 = self.pos
+      while true # sequence
+        _tmp = apply(:_fact)
+        f1 = @result
+        unless _tmp
+          self.pos = _save2
+          break
+        end
+        _tmp = apply(:__hyphen_)
+        unless _tmp
+          self.pos = _save2
+          break
+        end
+        _tmp = match_string("/")
+        unless _tmp
+          self.pos = _save2
+          break
+        end
+        _tmp = apply(:__hyphen_)
+        unless _tmp
+          self.pos = _save2
+          break
+        end
+        _tmp = apply(:_fact)
+        f2 = @result
+        unless _tmp
+          self.pos = _save2
+          break
+        end
+        @result = begin;  f1 / f2 ; end
+        _tmp = true
+        unless _tmp
+          self.pos = _save2
+        end
+        break
+      end # end sequence
+
+      break if _tmp
+      self.pos = _save
+      _tmp = apply(:_num)
+      break if _tmp
+      self.pos = _save
+      break
+    end # end choice
+
+    set_failed_rule :_fact unless _tmp
+    return _tmp
+  end
+
+  # root = term:t { @result = t }
   def _root
 
     _save = self.pos
     while true # sequence
-      _tmp = match_string("[")
+      _tmp = apply(:_term)
+      t = @result
       unless _tmp
         self.pos = _save
         break
       end
-      _tmp = apply(:_equals)
-      e = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = match_string("[")
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _text_start = self.pos
-      while true
-
-        _save2 = self.pos
-        while true # sequence
-          _save3 = self.pos
-          _tmp = apply_with_args(:_equal_ending, e)
-          _tmp = _tmp ? nil : true
-          self.pos = _save3
-          unless _tmp
-            self.pos = _save2
-            break
-          end
-          _tmp = get_byte
-          unless _tmp
-            self.pos = _save2
-          end
-          break
-        end # end sequence
-
-        break unless _tmp
-      end
-      _tmp = true
-      if _tmp
-        text = get_text(_text_start)
-      end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = apply_with_args(:_equal_ending, e)
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin; 
-         @result = text
-       ; end
+      @result = begin;  @result = t ; end
       _tmp = true
       unless _tmp
         self.pos = _save
@@ -531,8 +654,11 @@ class LuaString
   end
 
   Rules = {}
-  Rules[:_equals] = rule_info("equals", "< \"=\"* > { text }")
-  Rules[:_equal_ending] = rule_info("equal_ending", "\"]\" equals:x &{ x == start } \"]\"")
-  Rules[:_root] = rule_info("root", "\"[\" equals:e \"[\" < (!equal_ending(e) .)* > equal_ending(e) {          @result = text        }")
+  Rules[:_space] = rule_info("space", "\" \"")
+  Rules[:__hyphen_] = rule_info("-", "space*")
+  Rules[:_num] = rule_info("num", "< /[1-9][0-9]*/ > { text.to_i }")
+  Rules[:_term] = rule_info("term", "(term:t1 - \"+\" - term:t2 { t1 + t2 } | term:t1 - \"-\" - term:t2 { t1 - t2 } | fact)")
+  Rules[:_fact] = rule_info("fact", "(fact:f1 - \"*\" - fact:f2 { f1 * f2 } | fact:f1 - \"/\" - fact:f2 { f1 / f2 } | num)")
+  Rules[:_root] = rule_info("root", "term:t { @result = t }")
   # :startdoc:
 end

--- a/examples/foreign_reference/literals.kpeg.rb
+++ b/examples/foreign_reference/literals.kpeg.rb
@@ -1,4 +1,4 @@
-class LuaString
+class Literal
   # :stopdoc:
 
     # This is distinct from setup_parser so that a standalone parser
@@ -388,151 +388,33 @@ class LuaString
 
 
   # :startdoc:
-
-
-  attr_accessor :result
-
-
   # :stopdoc:
   def setup_foreign_grammar; end
 
-  # equals = < "="* > { text }
-  def _equals
-
-    _save = self.pos
-    while true # sequence
-      _text_start = self.pos
-      while true
-        _tmp = match_string("=")
-        break unless _tmp
-      end
-      _tmp = true
-      if _tmp
-        text = get_text(_text_start)
-      end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  text ; end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_equals unless _tmp
+  # period = "."
+  def _period
+    _tmp = match_string(".")
+    set_failed_rule :_period unless _tmp
     return _tmp
   end
 
-  # equal_ending = "]" equals:x &{ x == start } "]"
-  def _equal_ending(start)
-
-    _save = self.pos
-    while true # sequence
-      _tmp = match_string("]")
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = apply(:_equals)
-      x = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save1 = self.pos
-      _tmp = begin;  x == start ; end
-      self.pos = _save1
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = match_string("]")
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_equal_ending unless _tmp
+  # space = " "
+  def _space
+    _tmp = match_string(" ")
+    set_failed_rule :_space unless _tmp
     return _tmp
   end
 
-  # root = "[" equals:e "[" < (!equal_ending(e) .)* > equal_ending(e) {          @result = text        }
-  def _root
-
-    _save = self.pos
-    while true # sequence
-      _tmp = match_string("[")
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = apply(:_equals)
-      e = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = match_string("[")
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _text_start = self.pos
-      while true
-
-        _save2 = self.pos
-        while true # sequence
-          _save3 = self.pos
-          _tmp = apply_with_args(:_equal_ending, e)
-          _tmp = _tmp ? nil : true
-          self.pos = _save3
-          unless _tmp
-            self.pos = _save2
-            break
-          end
-          _tmp = get_byte
-          unless _tmp
-            self.pos = _save2
-          end
-          break
-        end # end sequence
-
-        break unless _tmp
-      end
-      _tmp = true
-      if _tmp
-        text = get_text(_text_start)
-      end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = apply_with_args(:_equal_ending, e)
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin; 
-         @result = text
-       ; end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_root unless _tmp
+  # alpha = /[A-Za-z]/
+  def _alpha
+    _tmp = scan(/\G(?-mix:[A-Za-z])/)
+    set_failed_rule :_alpha unless _tmp
     return _tmp
   end
 
   Rules = {}
-  Rules[:_equals] = rule_info("equals", "< \"=\"* > { text }")
-  Rules[:_equal_ending] = rule_info("equal_ending", "\"]\" equals:x &{ x == start } \"]\"")
-  Rules[:_root] = rule_info("root", "\"[\" equals:e \"[\" < (!equal_ending(e) .)* > equal_ending(e) {          @result = text        }")
+  Rules[:_period] = rule_info("period", "\".\"")
+  Rules[:_space] = rule_info("space", "\" \"")
+  Rules[:_alpha] = rule_info("alpha", "/[A-Za-z]/")
   # :startdoc:
 end

--- a/examples/foreign_reference/literals.kpeg.rb
+++ b/examples/foreign_reference/literals.kpeg.rb
@@ -197,6 +197,15 @@ class Literal
 
     attr_reader :failed_rule
 
+    def match_dot()
+      if @pos >= @string_size
+        return nil
+      end
+
+      @pos += 1
+      true
+    end
+
     def match_string(str)
       len = str.size
       if @string[pos,len] == str
@@ -217,24 +226,26 @@ class Literal
     end
 
     if "".respond_to? :ord
-      def get_byte
+      def match_char_range(char_range)
         if @pos >= @string_size
+          return nil
+        elsif !char_range.include?(@string[@pos].ord)
           return nil
         end
 
-        s = @string[@pos].ord
         @pos += 1
-        s
+        true
       end
     else
-      def get_byte
+      def match_char_range(char_range)
         if @pos >= @string_size
+          return nil
+        elsif !char_range.include?(@string[@pos])
           return nil
         end
 
-        s = @string[@pos]
         @pos += 1
-        s
+        true
       end
     end
 

--- a/examples/foreign_reference/literals.kpeg.rb
+++ b/examples/foreign_reference/literals.kpeg.rb
@@ -53,6 +53,9 @@ class Literal
       def current_line(target=pos)
         if line = position_line_offsets.bsearch_index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
         raise "Target position #{target} is outside of string"
       end
@@ -60,17 +63,22 @@ class Literal
       def current_line(target=pos)
         if line = position_line_offsets.index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
-
         raise "Target position #{target} is outside of string"
       end
     end
 
     def current_character(target=pos)
-      if target < 0 || target >= string.size
+      if target < 0 || target > string.size
         raise "Target position #{target} is outside of string"
+      elsif target == string.size
+        ""
+      else
+        string[target, 1]
       end
-      string[target, 1]
     end
 
     KpegPosInfo = Struct.new(:pos, :lno, :col, :line, :char)

--- a/examples/foreign_reference/matcher.kpeg.rb
+++ b/examples/foreign_reference/matcher.kpeg.rb
@@ -53,6 +53,9 @@ class Matcher
       def current_line(target=pos)
         if line = position_line_offsets.bsearch_index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
         raise "Target position #{target} is outside of string"
       end
@@ -60,17 +63,22 @@ class Matcher
       def current_line(target=pos)
         if line = position_line_offsets.index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
-
         raise "Target position #{target} is outside of string"
       end
     end
 
     def current_character(target=pos)
-      if target < 0 || target >= string.size
+      if target < 0 || target > string.size
         raise "Target position #{target} is outside of string"
+      elsif target == string.size
+        ""
+      else
+        string[target, 1]
       end
-      string[target, 1]
     end
 
     KpegPosInfo = Struct.new(:pos, :lno, :col, :line, :char)

--- a/examples/foreign_reference/matcher.kpeg.rb
+++ b/examples/foreign_reference/matcher.kpeg.rb
@@ -1,4 +1,4 @@
-class LuaString
+class Matcher
   # :stopdoc:
 
     # This is distinct from setup_parser so that a standalone parser
@@ -390,136 +390,71 @@ class LuaString
   # :startdoc:
 
 
-  attr_accessor :result
+	require "literals.kpeg.rb"
 
 
   # :stopdoc:
-  def setup_foreign_grammar; end
-
-  # equals = < "="* > { text }
-  def _equals
-
-    _save = self.pos
-    while true # sequence
-      _text_start = self.pos
-      while true
-        _tmp = match_string("=")
-        break unless _tmp
-      end
-      _tmp = true
-      if _tmp
-        text = get_text(_text_start)
-      end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  text ; end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_equals unless _tmp
-    return _tmp
+  def setup_foreign_grammar
+    @_grammar_grammer1 = Literal.new(nil)
   end
 
-  # equal_ending = "]" equals:x &{ x == start } "]"
-  def _equal_ending(start)
-
-    _save = self.pos
-    while true # sequence
-      _tmp = match_string("]")
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = apply(:_equals)
-      x = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save1 = self.pos
-      _tmp = begin;  x == start ; end
-      self.pos = _save1
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = match_string("]")
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
-
-    set_failed_rule :_equal_ending unless _tmp
-    return _tmp
-  end
-
-  # root = "[" equals:e "[" < (!equal_ending(e) .)* > equal_ending(e) {          @result = text        }
+  # root = (%grammer1.alpha %grammer1.space*)+ %grammer1.period
   def _root
 
     _save = self.pos
     while true # sequence
-      _tmp = match_string("[")
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = apply(:_equals)
-      e = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = match_string("[")
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _text_start = self.pos
-      while true
+      _save1 = self.pos
 
-        _save2 = self.pos
-        while true # sequence
-          _save3 = self.pos
-          _tmp = apply_with_args(:_equal_ending, e)
-          _tmp = _tmp ? nil : true
-          self.pos = _save3
-          unless _tmp
-            self.pos = _save2
-            break
-          end
-          _tmp = get_byte
-          unless _tmp
-            self.pos = _save2
-          end
+      _save2 = self.pos
+      while true # sequence
+        _tmp = @_grammar_grammer1.external_invoke(self, :_alpha)
+        unless _tmp
+          self.pos = _save2
           break
-        end # end sequence
+        end
+        while true
+          _tmp = @_grammar_grammer1.external_invoke(self, :_space)
+          break unless _tmp
+        end
+        _tmp = true
+        unless _tmp
+          self.pos = _save2
+        end
+        break
+      end # end sequence
 
-        break unless _tmp
-      end
-      _tmp = true
       if _tmp
-        text = get_text(_text_start)
+        while true
+
+          _save4 = self.pos
+          while true # sequence
+            _tmp = @_grammar_grammer1.external_invoke(self, :_alpha)
+            unless _tmp
+              self.pos = _save4
+              break
+            end
+            while true
+              _tmp = @_grammar_grammer1.external_invoke(self, :_space)
+              break unless _tmp
+            end
+            _tmp = true
+            unless _tmp
+              self.pos = _save4
+            end
+            break
+          end # end sequence
+
+          break unless _tmp
+        end
+        _tmp = true
+      else
+        self.pos = _save1
       end
       unless _tmp
         self.pos = _save
         break
       end
-      _tmp = apply_with_args(:_equal_ending, e)
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin; 
-         @result = text
-       ; end
-      _tmp = true
+      _tmp = @_grammar_grammer1.external_invoke(self, :_period)
       unless _tmp
         self.pos = _save
       end
@@ -531,8 +466,6 @@ class LuaString
   end
 
   Rules = {}
-  Rules[:_equals] = rule_info("equals", "< \"=\"* > { text }")
-  Rules[:_equal_ending] = rule_info("equal_ending", "\"]\" equals:x &{ x == start } \"]\"")
-  Rules[:_root] = rule_info("root", "\"[\" equals:e \"[\" < (!equal_ending(e) .)* > equal_ending(e) {          @result = text        }")
+  Rules[:_root] = rule_info("root", "(%grammer1.alpha %grammer1.space*)+ %grammer1.period")
   # :startdoc:
 end

--- a/examples/foreign_reference/matcher.kpeg.rb
+++ b/examples/foreign_reference/matcher.kpeg.rb
@@ -197,6 +197,15 @@ class Matcher
 
     attr_reader :failed_rule
 
+    def match_dot()
+      if @pos >= @string_size
+        return nil
+      end
+
+      @pos += 1
+      true
+    end
+
     def match_string(str)
       len = str.size
       if @string[pos,len] == str
@@ -217,24 +226,26 @@ class Matcher
     end
 
     if "".respond_to? :ord
-      def get_byte
+      def match_char_range(char_range)
         if @pos >= @string_size
+          return nil
+        elsif !char_range.include?(@string[@pos].ord)
           return nil
         end
 
-        s = @string[@pos].ord
         @pos += 1
-        s
+        true
       end
     else
-      def get_byte
+      def match_char_range(char_range)
         if @pos >= @string_size
+          return nil
+        elsif !char_range.include?(@string[@pos])
           return nil
         end
 
-        s = @string[@pos]
         @pos += 1
-        s
+        true
       end
     end
 
@@ -410,63 +421,37 @@ class Matcher
   def _root
 
     _save = self.pos
-    while true # sequence
-      _save1 = self.pos
+    begin # sequence
+      _save1 = self.pos # repetition
+      _count = 0
+      while true
 
-      _save2 = self.pos
-      while true # sequence
-        _tmp = @_grammar_grammer1.external_invoke(self, :_alpha)
+        _save2 = self.pos
+        begin # sequence
+          _tmp = @_grammar_grammer1.external_invoke(self, :_alpha)
+          break unless _tmp
+          while true # kleene
+            _tmp = @_grammar_grammer1.external_invoke(self, :_space)
+            break unless _tmp
+          end
+          _tmp = true # end kleene
+        end while false
         unless _tmp
           self.pos = _save2
-          break
-        end
-        while true
-          _tmp = @_grammar_grammer1.external_invoke(self, :_space)
-          break unless _tmp
-        end
-        _tmp = true
-        unless _tmp
-          self.pos = _save2
-        end
-        break
-      end # end sequence
+        end # end sequence
 
-      if _tmp
-        while true
-
-          _save4 = self.pos
-          while true # sequence
-            _tmp = @_grammar_grammer1.external_invoke(self, :_alpha)
-            unless _tmp
-              self.pos = _save4
-              break
-            end
-            while true
-              _tmp = @_grammar_grammer1.external_invoke(self, :_space)
-              break unless _tmp
-            end
-            _tmp = true
-            unless _tmp
-              self.pos = _save4
-            end
-            break
-          end # end sequence
-
-          break unless _tmp
-        end
-        _tmp = true
-      else
+        break unless _tmp
+        _count += 1
+      end
+      _tmp = _count >= 1
+      unless _tmp
         self.pos = _save1
-      end
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      end # end repetition
+      break unless _tmp
       _tmp = @_grammar_grammer1.external_invoke(self, :_period)
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_root unless _tmp

--- a/examples/lua_string/lua_string.kpeg.rb
+++ b/examples/lua_string/lua_string.kpeg.rb
@@ -53,6 +53,9 @@ class LuaString
       def current_line(target=pos)
         if line = position_line_offsets.bsearch_index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
         raise "Target position #{target} is outside of string"
       end
@@ -60,17 +63,22 @@ class LuaString
       def current_line(target=pos)
         if line = position_line_offsets.index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
-
         raise "Target position #{target} is outside of string"
       end
     end
 
     def current_character(target=pos)
-      if target < 0 || target >= string.size
+      if target < 0 || target > string.size
         raise "Target position #{target} is outside of string"
+      elsif target == string.size
+        ""
+      else
+        string[target, 1]
       end
-      string[target, 1]
     end
 
     KpegPosInfo = Struct.new(:pos, :lno, :col, :line, :char)

--- a/examples/phone_number/phone_number.kpeg.rb
+++ b/examples/phone_number/phone_number.kpeg.rb
@@ -197,6 +197,15 @@ class PhoneNumber
 
     attr_reader :failed_rule
 
+    def match_dot()
+      if @pos >= @string_size
+        return nil
+      end
+
+      @pos += 1
+      true
+    end
+
     def match_string(str)
       len = str.size
       if @string[pos,len] == str
@@ -217,24 +226,26 @@ class PhoneNumber
     end
 
     if "".respond_to? :ord
-      def get_byte
+      def match_char_range(char_range)
         if @pos >= @string_size
+          return nil
+        elsif !char_range.include?(@string[@pos].ord)
           return nil
         end
 
-        s = @string[@pos].ord
         @pos += 1
-        s
+        true
       end
     else
-      def get_byte
+      def match_char_range(char_range)
         if @pos >= @string_size
+          return nil
+        elsif !char_range.include?(@string[@pos])
           return nil
         end
 
-        s = @string[@pos]
         @pos += 1
-        s
+        true
       end
     end
 
@@ -406,14 +417,7 @@ class PhoneNumber
 
   # digit = [0-9]
   def _digit
-    _save = self.pos
-    _tmp = get_byte
-    if _tmp
-      unless _tmp >= 48 and _tmp <= 57
-        self.pos = _save
-        _tmp = nil
-      end
-    end
+    _tmp = match_char_range(48..57)
     set_failed_rule :_digit unless _tmp
     return _tmp
   end
@@ -450,22 +454,18 @@ class PhoneNumber
   def _country_code
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _text_start = self.pos
       _tmp = apply(:_digit)
       if _tmp
         text = get_text(_text_start)
       end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  text ; end
+      break unless _tmp
+      @result = begin; text; end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_country_code unless _tmp
@@ -476,38 +476,29 @@ class PhoneNumber
   def _area_code
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _text_start = self.pos
-      _save1 = self.pos
+      _save1 = self.pos # repetition
       _count = 0
       while true
         _tmp = apply(:_digit)
-        if _tmp
-          _count += 1
-          break if _count == 3
-        else
-          break
-        end
+        break unless _tmp
+        _count += 1
+        break if _count == 3
       end
-      if _count >= 3
-        _tmp = true
-      else
+      _tmp = _count >= 3
+      unless _tmp
         self.pos = _save1
-        _tmp = nil
-      end
+      end # end repetition
       if _tmp
         text = get_text(_text_start)
       end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  text ; end
+      break unless _tmp
+      @result = begin; text; end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_area_code unless _tmp
@@ -518,38 +509,29 @@ class PhoneNumber
   def _prefix
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _text_start = self.pos
-      _save1 = self.pos
+      _save1 = self.pos # repetition
       _count = 0
       while true
         _tmp = apply(:_digit)
-        if _tmp
-          _count += 1
-          break if _count == 3
-        else
-          break
-        end
+        break unless _tmp
+        _count += 1
+        break if _count == 3
       end
-      if _count >= 3
-        _tmp = true
-      else
+      _tmp = _count >= 3
+      unless _tmp
         self.pos = _save1
-        _tmp = nil
-      end
+      end # end repetition
       if _tmp
         text = get_text(_text_start)
       end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  text ; end
+      break unless _tmp
+      @result = begin; text; end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_prefix unless _tmp
@@ -560,38 +542,29 @@ class PhoneNumber
   def _suffix
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _text_start = self.pos
-      _save1 = self.pos
+      _save1 = self.pos # repetition
       _count = 0
       while true
         _tmp = apply(:_digit)
-        if _tmp
-          _count += 1
-          break if _count == 4
-        else
-          break
-        end
+        break unless _tmp
+        _count += 1
+        break if _count == 4
       end
-      if _count >= 4
-        _tmp = true
-      else
+      _tmp = _count >= 4
+      unless _tmp
         self.pos = _save1
-        _tmp = nil
-      end
+      end # end repetition
       if _tmp
         text = get_text(_text_start)
       end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  text ; end
+      break unless _tmp
+      @result = begin; text; end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_suffix unless _tmp
@@ -602,97 +575,57 @@ class PhoneNumber
   def _phone_number
 
     _save = self.pos
-    while true # sequence
-      _save1 = self.pos
+    begin # sequence
+      # optional
       _tmp = apply(:_LP)
-      unless _tmp
-        _tmp = true
-        self.pos = _save1
-      end
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      _tmp = true # end optional
+      break unless _tmp
       _tmp = apply(:_area_code)
       ac = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save2 = self.pos
+      break unless _tmp
+      # optional
       _tmp = apply(:_RP)
-      unless _tmp
-        _tmp = true
-        self.pos = _save2
-      end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      while true
+      _tmp = true # end optional
+      break unless _tmp
+      while true # kleene
         _tmp = apply(:_space)
         break unless _tmp
       end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      _tmp = true # end kleene
+      break unless _tmp
       _tmp = apply(:_prefix)
       p = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      while true
+      break unless _tmp
+      while true # kleene
         _tmp = apply(:_space)
         break unless _tmp
       end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save5 = self.pos
+      _tmp = true # end kleene
+      break unless _tmp
+      # optional
       _tmp = apply(:_dash)
-      unless _tmp
-        _tmp = true
-        self.pos = _save5
-      end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      while true
+      _tmp = true # end optional
+      break unless _tmp
+      while true # kleene
         _tmp = apply(:_space)
         break unless _tmp
       end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      _tmp = true # end kleene
+      break unless _tmp
       _tmp = apply(:_suffix)
       s = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      while true
+      break unless _tmp
+      while true # kleene
         _tmp = apply(:_space)
         break unless _tmp
       end
+      _tmp = true # end kleene
+      break unless _tmp
+      @result = begin; "(#{ac}) #{p}-#{s}"; end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  "(#{ac}) #{p}-#{s}" ; end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_phone_number unless _tmp
@@ -702,63 +635,44 @@ class PhoneNumber
   # root = (phone_number:pn { @phone_number = pn } | country_code:c space* phone_number:pn { @phone_number = "+#{c} #{pn}" })
   def _root
 
-    _save = self.pos
-    while true # choice
+    begin # choice
 
-      _save1 = self.pos
-      while true # sequence
+      _save = self.pos
+      begin # sequence
         _tmp = apply(:_phone_number)
         pn = @result
-        unless _tmp
-          self.pos = _save1
-          break
-        end
-        @result = begin;  @phone_number = pn ; end
+        break unless _tmp
+        @result = begin; @phone_number = pn; end
         _tmp = true
-        unless _tmp
-          self.pos = _save1
-        end
-        break
+      end while false
+      unless _tmp
+        self.pos = _save
       end # end sequence
 
       break if _tmp
-      self.pos = _save
 
-      _save2 = self.pos
-      while true # sequence
+      _save1 = self.pos
+      begin # sequence
         _tmp = apply(:_country_code)
         c = @result
-        unless _tmp
-          self.pos = _save2
-          break
-        end
-        while true
+        break unless _tmp
+        while true # kleene
           _tmp = apply(:_space)
           break unless _tmp
         end
-        _tmp = true
-        unless _tmp
-          self.pos = _save2
-          break
-        end
+        _tmp = true # end kleene
+        break unless _tmp
         _tmp = apply(:_phone_number)
         pn = @result
-        unless _tmp
-          self.pos = _save2
-          break
-        end
-        @result = begin;  @phone_number = "+#{c} #{pn}" ; end
+        break unless _tmp
+        @result = begin; @phone_number = "+#{c} #{pn}"; end
         _tmp = true
-        unless _tmp
-          self.pos = _save2
-        end
-        break
+      end while false
+      unless _tmp
+        self.pos = _save1
       end # end sequence
 
-      break if _tmp
-      self.pos = _save
-      break
-    end # end choice
+    end while false # end choice
 
     set_failed_rule :_root unless _tmp
     return _tmp

--- a/examples/phone_number/phone_number.kpeg.rb
+++ b/examples/phone_number/phone_number.kpeg.rb
@@ -53,6 +53,9 @@ class PhoneNumber
       def current_line(target=pos)
         if line = position_line_offsets.bsearch_index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
         raise "Target position #{target} is outside of string"
       end
@@ -60,17 +63,22 @@ class PhoneNumber
       def current_line(target=pos)
         if line = position_line_offsets.index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
-
         raise "Target position #{target} is outside of string"
       end
     end
 
     def current_character(target=pos)
-      if target < 0 || target >= string.size
+      if target < 0 || target > string.size
         raise "Target position #{target} is outside of string"
+      elsif target == string.size
+        ""
+      else
+        string[target, 1]
       end
-      string[target, 1]
     end
 
     KpegPosInfo = Struct.new(:pos, :lno, :col, :line, :char)

--- a/examples/tiny_markdown/tiny_markdown.kpeg.rb
+++ b/examples/tiny_markdown/tiny_markdown.kpeg.rb
@@ -18,6 +18,7 @@ class TinyMarkdown::Parser
       @result = nil
       @failed_rule = nil
       @failing_rule_offset = -1
+      @line_offsets = nil
 
       setup_foreign_grammar
     end
@@ -27,30 +28,75 @@ class TinyMarkdown::Parser
     attr_accessor :result, :pos
 
     def current_column(target=pos)
-      if c = string.rindex("\n", target-1)
-        return target - c - 1
+      if string[target] == "\n" && (c = string.rindex("\n", target-1) || -1)
+        return target - c
+      elsif c = string.rindex("\n", target)
+        return target - c
       end
 
       target + 1
     end
 
-    def current_line(target=pos)
-      cur_offset = 0
-      cur_line = 0
-
-      string.each_line do |line|
-        cur_line += 1
-        cur_offset += line.size
-        return cur_line if cur_offset >= target
+    def position_line_offsets
+      unless @position_line_offsets
+        @position_line_offsets = []
+        total = 0
+        string.each_line do |line|
+          total += line.size
+          @position_line_offsets << total
+        end
       end
+      @position_line_offsets
+    end
 
-      -1
+    if [].respond_to? :bsearch_index
+      def current_line(target=pos)
+        if line = position_line_offsets.bsearch_index {|x| x > target }
+          return line + 1
+        end
+        raise "Target position #{target} is outside of string"
+      end
+    else
+      def current_line(target=pos)
+        if line = position_line_offsets.index {|x| x > target }
+          return line + 1
+        end
+
+        raise "Target position #{target} is outside of string"
+      end
+    end
+
+    def current_character(target=pos)
+      if target < 0 || target >= string.size
+        raise "Target position #{target} is outside of string"
+      end
+      string[target, 1]
+    end
+
+    KpegPosInfo = Struct.new(:pos, :lno, :col, :line, :char)
+
+    def current_pos_info(target=pos)
+      l = current_line target
+      c = current_column target
+      ln = get_line(l-1)
+      chr = string[target,1]
+      KpegPosInfo.new(target, l, c, ln, chr)
     end
 
     def lines
-      lines = []
-      string.each_line { |l| lines << l }
-      lines
+      string.lines
+    end
+
+    def get_line(no)
+      loff = position_line_offsets
+      if no < 0
+        raise "Line No is out of range: #{no} < 0"
+      elsif no >= loff.size
+        raise "Line No is out of range: #{no} >= #{loff.size}"
+      end
+      lend = loff[no]-1
+      lstart = no > 0 ? loff[no-1] : 0
+      string[lstart..lend]
     end
 
 
@@ -64,6 +110,7 @@ class TinyMarkdown::Parser
       @string = string
       @string_size = string ? string.size : 0
       @pos = pos
+      @position_line_offsets = nil
     end
 
     def show_pos
@@ -88,30 +135,22 @@ class TinyMarkdown::Parser
     end
 
     def failure_caret
-      l = current_line @failing_rule_offset
-      c = current_column @failing_rule_offset
-
-      line = lines[l-1]
-      "#{line}\n#{' ' * (c - 1)}^"
+      p = current_pos_info @failing_rule_offset
+      "#{p.line.chomp}\n#{' ' * (p.col - 1)}^"
     end
 
     def failure_character
-      l = current_line @failing_rule_offset
-      c = current_column @failing_rule_offset
-      lines[l-1][c-1, 1]
+      current_character @failing_rule_offset
     end
 
     def failure_oneline
-      l = current_line @failing_rule_offset
-      c = current_column @failing_rule_offset
-
-      char = lines[l-1][c-1, 1]
+      p = current_pos_info @failing_rule_offset
 
       if @failed_rule.kind_of? Symbol
         info = self.class::Rules[@failed_rule]
-        "@#{l}:#{c} failed rule '#{info.name}', got '#{char}'"
+        "@#{p.lno}:#{p.col} failed rule '#{info.name}', got '#{p.char}'"
       else
-        "@#{l}:#{c} failed rule '#{@failed_rule}', got '#{char}'"
+        "@#{p.lno}:#{p.col} failed rule '#{@failed_rule}', got '#{p.char}'"
       end
     end
 
@@ -124,10 +163,9 @@ class TinyMarkdown::Parser
 
     def show_error(io=STDOUT)
       error_pos = @failing_rule_offset
-      line_no = current_line(error_pos)
-      col_no = current_column(error_pos)
+      p = current_pos_info(error_pos)
 
-      io.puts "On line #{line_no}, column #{col_no}:"
+      io.puts "On line #{p.lno}, column #{p.col}:"
 
       if @failed_rule.kind_of? Symbol
         info = self.class::Rules[@failed_rule]
@@ -136,10 +174,9 @@ class TinyMarkdown::Parser
         io.puts "Failed to match rule '#{@failed_rule}'"
       end
 
-      io.puts "Got: #{string[error_pos,1].inspect}"
-      line = lines[line_no-1]
-      io.puts "=> #{line}"
-      io.print(" " * (col_no + 3))
+      io.puts "Got: #{p.char.inspect}"
+      io.puts "=> #{p.line}"
+      io.print(" " * (p.col + 2))
       io.puts "^"
     end
 
@@ -163,9 +200,8 @@ class TinyMarkdown::Parser
     end
 
     def scan(reg)
-      if m = reg.match(@string[@pos..-1])
-        width = m.end(0)
-        @pos += width
+      if m = reg.match(@string, @pos)
+        @pos = m.end(0)
         return true
       end
 
@@ -249,6 +285,7 @@ class TinyMarkdown::Parser
     end
 
     def apply_with_args(rule, *args)
+      @result = nil
       memo_key = [rule, args]
       if m = @memoizations[memo_key][@pos]
         @pos = m.pos
@@ -278,12 +315,11 @@ class TinyMarkdown::Parser
         else
           return ans
         end
-
-        return ans
       end
     end
 
     def apply(rule)
+      @result = nil
       if m = @memoizations[rule][@pos]
         @pos = m.pos
         if !m.set
@@ -312,8 +348,6 @@ class TinyMarkdown::Parser
         else
           return ans
         end
-
-        return ans
       end
     end
 
@@ -808,7 +842,7 @@ class TinyMarkdown::Parser
     _save = self.pos
     while true # sequence
       _text_start = self.pos
-      _tmp = scan(/\A(?-mix:######|#####|####|###|##|#)/)
+      _tmp = scan(/\G(?-mix:######|#####|####|###|##|#)/)
       if _tmp
         text = get_text(_text_start)
       end
@@ -2941,7 +2975,7 @@ class TinyMarkdown::Parser
     _save = self.pos
     while true # sequence
       _text_start = self.pos
-      _tmp = scan(/\A(?-mix:`)/)
+      _tmp = scan(/\G(?-mix:`)/)
       if _tmp
         text = get_text(_text_start)
       end
@@ -2975,7 +3009,7 @@ class TinyMarkdown::Parser
     _save = self.pos
     while true # sequence
       _text_start = self.pos
-      _tmp = scan(/\A(?-mix:``)/)
+      _tmp = scan(/\G(?-mix:``)/)
       if _tmp
         text = get_text(_text_start)
       end
@@ -3340,7 +3374,7 @@ class TinyMarkdown::Parser
     _save = self.pos
     while true # sequence
       _text_start = self.pos
-      _tmp = scan(/\A(?-mix: |\t)/)
+      _tmp = scan(/\G(?-mix: |\t)/)
       if _tmp
         text = get_text(_text_start)
       end
@@ -3496,7 +3530,7 @@ class TinyMarkdown::Parser
     _save = self.pos
     while true # sequence
       _text_start = self.pos
-      _tmp = scan(/\A(?-mix:[~*_`&\[\]()<!#\\'"])/)
+      _tmp = scan(/\G(?-mix:[~*_`&\[\]()<!#\\'"])/)
       if _tmp
         text = get_text(_text_start)
       end
@@ -3570,7 +3604,7 @@ class TinyMarkdown::Parser
     _save = self.pos
     while true # sequence
       _text_start = self.pos
-      _tmp = scan(/\A(?-mix:[A-Za-z0-9])/)
+      _tmp = scan(/\G(?-mix:[A-Za-z0-9])/)
       if _tmp
         text = get_text(_text_start)
       end
@@ -3596,7 +3630,7 @@ class TinyMarkdown::Parser
     _save = self.pos
     while true # sequence
       _text_start = self.pos
-      _tmp = scan(/\A(?-mix:[0-9])/)
+      _tmp = scan(/\G(?-mix:[0-9])/)
       if _tmp
         text = get_text(_text_start)
       end
@@ -3622,7 +3656,7 @@ class TinyMarkdown::Parser
     _save = self.pos
     while true # sequence
       _text_start = self.pos
-      _tmp = scan(/\A(?-mix:   |  | |)/)
+      _tmp = scan(/\G(?-mix:   |  | |)/)
       if _tmp
         text = get_text(_text_start)
       end
@@ -3648,7 +3682,7 @@ class TinyMarkdown::Parser
     _save = self.pos
     while true # sequence
       _text_start = self.pos
-      _tmp = scan(/\A(?-mix:\t|    )/)
+      _tmp = scan(/\G(?-mix:\t|    )/)
       if _tmp
         text = get_text(_text_start)
       end
@@ -3757,7 +3791,7 @@ class TinyMarkdown::Parser
         _save2 = self.pos
         while true # sequence
           _text_start = self.pos
-          _tmp = scan(/\A(?-mix:[^\r\n]*)/)
+          _tmp = scan(/\G(?-mix:[^\r\n]*)/)
           if _tmp
             text = get_text(_text_start)
           end
@@ -3784,7 +3818,7 @@ class TinyMarkdown::Parser
         _save3 = self.pos
         while true # sequence
           _text_start = self.pos
-          _tmp = scan(/\A(?-mix:.+)/)
+          _tmp = scan(/\G(?-mix:.+)/)
           if _tmp
             text = get_text(_text_start)
           end

--- a/examples/tiny_markdown/tiny_markdown.kpeg.rb
+++ b/examples/tiny_markdown/tiny_markdown.kpeg.rb
@@ -53,6 +53,9 @@ class TinyMarkdown::Parser
       def current_line(target=pos)
         if line = position_line_offsets.bsearch_index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
         raise "Target position #{target} is outside of string"
       end
@@ -60,17 +63,22 @@ class TinyMarkdown::Parser
       def current_line(target=pos)
         if line = position_line_offsets.index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
-
         raise "Target position #{target} is outside of string"
       end
     end
 
     def current_character(target=pos)
-      if target < 0 || target >= string.size
+      if target < 0 || target > string.size
         raise "Target position #{target} is outside of string"
+      elsif target == string.size
+        ""
+      else
+        string[target, 1]
       end
-      string[target, 1]
     end
 
     KpegPosInfo = Struct.new(:pos, :lno, :col, :line, :char)

--- a/examples/tiny_markdown/tiny_markdown.kpeg.rb
+++ b/examples/tiny_markdown/tiny_markdown.kpeg.rb
@@ -197,6 +197,15 @@ class TinyMarkdown::Parser
 
     attr_reader :failed_rule
 
+    def match_dot()
+      if @pos >= @string_size
+        return nil
+      end
+
+      @pos += 1
+      true
+    end
+
     def match_string(str)
       len = str.size
       if @string[pos,len] == str
@@ -217,24 +226,26 @@ class TinyMarkdown::Parser
     end
 
     if "".respond_to? :ord
-      def get_byte
+      def match_char_range(char_range)
         if @pos >= @string_size
+          return nil
+        elsif !char_range.include?(@string[@pos].ord)
           return nil
         end
 
-        s = @string[@pos].ord
         @pos += 1
-        s
+        true
       end
     else
-      def get_byte
+      def match_char_range(char_range)
         if @pos >= @string_size
+          return nil
+        elsif !char_range.include?(@string[@pos])
           return nil
         end
 
-        s = @string[@pos]
         @pos += 1
-        s
+        true
       end
     end
 
@@ -604,26 +615,19 @@ class TinyMarkdown::Parser
   def _Start
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _save1 = self.pos
-      _tmp = get_byte
+      _tmp = match_dot
       self.pos = _save1
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       _tmp = apply(:_Doc)
       c = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  @ast = c  ; end
+      break unless _tmp
+      @result = begin; @ast = c; end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_Start unless _tmp
@@ -634,26 +638,22 @@ class TinyMarkdown::Parser
   def _Doc
 
     _save = self.pos
-    while true # sequence
-      _ary = []
+    begin # sequence
+      _ary = [] # kleene
       while true
         _tmp = apply(:_Block)
-        _ary << @result if _tmp
         break unless _tmp
+        _ary << @result
       end
-      _tmp = true
       @result = _ary
+      _tmp = true # end kleene
       c = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       @result = begin; document(self, position, c); end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_Doc unless _tmp
@@ -664,47 +664,33 @@ class TinyMarkdown::Parser
   def _Block
 
     _save = self.pos
-    while true # sequence
-      while true
+    begin # sequence
+      while true # kleene
         _tmp = apply(:_BlankLine)
         break unless _tmp
       end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      _tmp = true # end kleene
+      break unless _tmp
 
-      _save2 = self.pos
-      while true # choice
+      begin # choice
         _tmp = apply(:_BlockQuote)
         break if _tmp
-        self.pos = _save2
         _tmp = apply(:_Verbatim)
         break if _tmp
-        self.pos = _save2
         _tmp = apply(:_HorizontalRule)
         break if _tmp
-        self.pos = _save2
         _tmp = apply(:_Heading)
         break if _tmp
-        self.pos = _save2
         _tmp = apply(:_BulletList)
         break if _tmp
-        self.pos = _save2
         _tmp = apply(:_Para)
         break if _tmp
-        self.pos = _save2
         _tmp = apply(:_Plain)
-        break if _tmp
-        self.pos = _save2
-        break
-      end # end choice
+      end while false # end choice
 
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_Block unless _tmp
@@ -715,39 +701,29 @@ class TinyMarkdown::Parser
   def _Para
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _tmp = apply(:_NonindentSpace)
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       _tmp = apply(:_Inlines)
       a = @result
-      unless _tmp
-        self.pos = _save
-        break
+      break unless _tmp
+      _save1 = self.pos # repetition
+      _count = 0
+      while true
+        _tmp = apply(:_BlankLine)
+        break unless _tmp
+        _count += 1
       end
-      _save1 = self.pos
-      _tmp = apply(:_BlankLine)
-      if _tmp
-        while true
-          _tmp = apply(:_BlankLine)
-          break unless _tmp
-        end
-        _tmp = true
-      else
+      _tmp = _count >= 1
+      unless _tmp
         self.pos = _save1
-      end
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      end # end repetition
+      break unless _tmp
       @result = begin; para(self, position, a); end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_Para unless _tmp
@@ -758,19 +734,15 @@ class TinyMarkdown::Parser
   def _Plain
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _tmp = apply(:_Inlines)
       a = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       @result = begin; plain(self, position, a); end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_Plain unless _tmp
@@ -781,63 +753,43 @@ class TinyMarkdown::Parser
   def _AtxInline
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _save1 = self.pos
       _tmp = apply(:_Newline)
-      _tmp = _tmp ? nil : true
+      _tmp = !_tmp
       self.pos = _save1
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       _save2 = self.pos
 
       _save3 = self.pos
-      while true # sequence
+      begin # sequence
         _tmp = apply(:_Sp)
-        unless _tmp
-          self.pos = _save3
-          break
-        end
-        while true
+        break unless _tmp
+        while true # kleene
           _tmp = match_string("#")
           break unless _tmp
         end
-        _tmp = true
-        unless _tmp
-          self.pos = _save3
-          break
-        end
+        _tmp = true # end kleene
+        break unless _tmp
         _tmp = apply(:_Sp)
-        unless _tmp
-          self.pos = _save3
-          break
-        end
+        break unless _tmp
         _tmp = apply(:_Newline)
-        unless _tmp
-          self.pos = _save3
-        end
-        break
+      end while false
+      unless _tmp
+        self.pos = _save3
       end # end sequence
 
-      _tmp = _tmp ? nil : true
+      _tmp = !_tmp
       self.pos = _save2
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       _tmp = apply(:_Inline)
       c = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  c ; end
+      break unless _tmp
+      @result = begin; c; end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_AtxInline unless _tmp
@@ -848,22 +800,18 @@ class TinyMarkdown::Parser
   def _AtxStart
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _text_start = self.pos
       _tmp = scan(/\G(?-mix:######|#####|####|###|##|#)/)
       if _tmp
         text = get_text(_text_start)
       end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  text.length ; end
+      break unless _tmp
+      @result = begin; text.length; end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_AtxStart unless _tmp
@@ -874,82 +822,54 @@ class TinyMarkdown::Parser
   def _AtxHeading
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _tmp = apply(:_AtxStart)
       level = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       _tmp = apply(:_Sp)
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save1 = self.pos
+      break unless _tmp
+      _save1 = self.pos # repetition
       _ary = []
-      _tmp = apply(:_AtxInline)
-      if _tmp
+      while true
+        _tmp = apply(:_AtxInline)
+        break unless _tmp
         _ary << @result
-        while true
-          _tmp = apply(:_AtxInline)
-          _ary << @result if _tmp
-          break unless _tmp
-        end
-        _tmp = true
-        @result = _ary
-      else
-        self.pos = _save1
       end
-      c = @result
+      @result = _ary
+      _tmp = _ary.size >= 1
       unless _tmp
-        self.pos = _save
-        break
-      end
-      _save2 = self.pos
+        self.pos = _save1
+        @result = nil
+      end # end repetition
+      c = @result
+      break unless _tmp
+      # optional
 
-      _save3 = self.pos
-      while true # sequence
+      _save2 = self.pos
+      begin # sequence
         _tmp = apply(:_Sp)
-        unless _tmp
-          self.pos = _save3
-          break
-        end
-        while true
+        break unless _tmp
+        while true # kleene
           _tmp = match_string("#")
           break unless _tmp
         end
-        _tmp = true
-        unless _tmp
-          self.pos = _save3
-          break
-        end
+        _tmp = true # end kleene
+        break unless _tmp
         _tmp = apply(:_Sp)
-        unless _tmp
-          self.pos = _save3
-        end
-        break
+      end while false
+      unless _tmp
+        self.pos = _save2
       end # end sequence
 
-      unless _tmp
-        _tmp = true
-        self.pos = _save2
-      end
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      _tmp = true # end optional
+      break unless _tmp
       _tmp = apply(:_Newline)
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       @result = begin; headline(self, position, level, c); end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_AtxHeading unless _tmp
@@ -967,19 +887,15 @@ class TinyMarkdown::Parser
   def _BlockQuote
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _tmp = apply(:_BlockQuoteRaw)
       c = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       @result = begin; block_quote(self, position, c); end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_BlockQuote unless _tmp
@@ -990,95 +906,45 @@ class TinyMarkdown::Parser
   def _BlockQuoteRaw
 
     _save = self.pos
-    while true # sequence
-      _save1 = self.pos
+    begin # sequence
+      _save1 = self.pos # repetition
       _ary = []
+      while true
 
-      _save2 = self.pos
-      while true # sequence
-        _tmp = match_string(">")
-        unless _tmp
-          self.pos = _save2
-          break
-        end
-        _save3 = self.pos
-        _tmp = match_string(" ")
-        unless _tmp
-          _tmp = true
-          self.pos = _save3
-        end
-        unless _tmp
-          self.pos = _save2
-          break
-        end
-        _tmp = apply(:_Line)
-        c = @result
-        unless _tmp
-          self.pos = _save2
-          break
-        end
-        @result = begin;  c ; end
-        _tmp = true
-        unless _tmp
-          self.pos = _save2
-        end
-        break
-      end # end sequence
-
-      if _tmp
-        _ary << @result
-        while true
-
-          _save4 = self.pos
-          while true # sequence
-            _tmp = match_string(">")
-            unless _tmp
-              self.pos = _save4
-              break
-            end
-            _save5 = self.pos
-            _tmp = match_string(" ")
-            unless _tmp
-              _tmp = true
-              self.pos = _save5
-            end
-            unless _tmp
-              self.pos = _save4
-              break
-            end
-            _tmp = apply(:_Line)
-            c = @result
-            unless _tmp
-              self.pos = _save4
-              break
-            end
-            @result = begin;  c ; end
-            _tmp = true
-            unless _tmp
-              self.pos = _save4
-            end
-            break
-          end # end sequence
-
-          _ary << @result if _tmp
+        _save2 = self.pos
+        begin # sequence
+          _tmp = match_string(">")
           break unless _tmp
-        end
-        _tmp = true
-        @result = _ary
-      else
+          # optional
+          _tmp = match_string(" ")
+          _tmp = true # end optional
+          break unless _tmp
+          _tmp = apply(:_Line)
+          c = @result
+          break unless _tmp
+          @result = begin; c; end
+          _tmp = true
+        end while false
+        unless _tmp
+          self.pos = _save2
+        end # end sequence
+
+        break unless _tmp
+        _ary << @result
+      end
+      @result = _ary
+      _tmp = _ary.size >= 1
+      unless _tmp
         self.pos = _save1
-      end
+        @result = nil
+      end # end repetition
       cc = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  cc ; end
+      break unless _tmp
+      @result = begin; cc; end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_BlockQuoteRaw unless _tmp
@@ -1089,27 +955,20 @@ class TinyMarkdown::Parser
   def _NonblankIndentedLine
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _save1 = self.pos
       _tmp = apply(:_BlankLine)
-      _tmp = _tmp ? nil : true
+      _tmp = !_tmp
       self.pos = _save1
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       _tmp = apply(:_IndentedLine)
       c = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  c ; end
+      break unless _tmp
+      @result = begin; c; end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_NonblankIndentedLine unless _tmp
@@ -1120,93 +979,60 @@ class TinyMarkdown::Parser
   def _VerbatimChunk
 
     _save = self.pos
-    while true # sequence
-      _ary = []
+    begin # sequence
+      _ary = [] # kleene
       while true
 
-        _save2 = self.pos
-        while true # sequence
+        _save1 = self.pos
+        begin # sequence
           _tmp = apply(:_BlankLine)
-          unless _tmp
-            self.pos = _save2
-            break
-          end
-          @result = begin;  text(self,position,"\n") ; end
+          break unless _tmp
+          @result = begin; text(self,position,"\n"); end
           _tmp = true
-          unless _tmp
-            self.pos = _save2
-          end
-          break
+        end while false
+        unless _tmp
+          self.pos = _save1
         end # end sequence
 
-        _ary << @result if _tmp
         break unless _tmp
-      end
-      _tmp = true
-      @result = _ary
-      c1 = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save3 = self.pos
-      _ary = []
-
-      _save4 = self.pos
-      while true # sequence
-        _tmp = apply(:_NonblankIndentedLine)
-        c = @result
-        unless _tmp
-          self.pos = _save4
-          break
-        end
-        @result = begin;  [c, text(self,position,"\n")] ; end
-        _tmp = true
-        unless _tmp
-          self.pos = _save4
-        end
-        break
-      end # end sequence
-
-      if _tmp
         _ary << @result
-        while true
+      end
+      @result = _ary
+      _tmp = true # end kleene
+      c1 = @result
+      break unless _tmp
+      _save2 = self.pos # repetition
+      _ary1 = []
+      while true
 
-          _save5 = self.pos
-          while true # sequence
-            _tmp = apply(:_NonblankIndentedLine)
-            c = @result
-            unless _tmp
-              self.pos = _save5
-              break
-            end
-            @result = begin;  [c, text(self,position,"\n")] ; end
-            _tmp = true
-            unless _tmp
-              self.pos = _save5
-            end
-            break
-          end # end sequence
-
-          _ary << @result if _tmp
+        _save3 = self.pos
+        begin # sequence
+          _tmp = apply(:_NonblankIndentedLine)
+          c = @result
           break unless _tmp
-        end
-        _tmp = true
-        @result = _ary
-      else
-        self.pos = _save3
+          @result = begin; [c, text(self,position,"\n")]; end
+          _tmp = true
+        end while false
+        unless _tmp
+          self.pos = _save3
+        end # end sequence
+
+        break unless _tmp
+        _ary1 << @result
       end
+      @result = _ary1
+      _tmp = _ary1.size >= 1
+      unless _tmp
+        self.pos = _save2
+        @result = nil
+      end # end repetition
       c2 = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  c1 + c2.flatten ; end
+      break unless _tmp
+      @result = begin; c1 + c2.flatten; end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_VerbatimChunk unless _tmp
@@ -1217,33 +1043,27 @@ class TinyMarkdown::Parser
   def _Verbatim
 
     _save = self.pos
-    while true # sequence
-      _save1 = self.pos
+    begin # sequence
+      _save1 = self.pos # repetition
       _ary = []
-      _tmp = apply(:_VerbatimChunk)
-      if _tmp
+      while true
+        _tmp = apply(:_VerbatimChunk)
+        break unless _tmp
         _ary << @result
-        while true
-          _tmp = apply(:_VerbatimChunk)
-          _ary << @result if _tmp
-          break unless _tmp
-        end
-        _tmp = true
-        @result = _ary
-      else
-        self.pos = _save1
       end
-      cc = @result
+      @result = _ary
+      _tmp = _ary.size >= 1
       unless _tmp
-        self.pos = _save
-        break
-      end
+        self.pos = _save1
+        @result = nil
+      end # end repetition
+      cc = @result
+      break unless _tmp
       @result = begin; verbatim(self, position, cc.flatten); end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_Verbatim unless _tmp
@@ -1254,218 +1074,136 @@ class TinyMarkdown::Parser
   def _HorizontalRule
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _tmp = apply(:_NonindentSpace)
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
 
-      _save1 = self.pos
-      while true # choice
+      begin # choice
 
-        _save2 = self.pos
-        while true # sequence
+        _save1 = self.pos
+        begin # sequence
           _tmp = match_string("*")
-          unless _tmp
-            self.pos = _save2
-            break
-          end
+          break unless _tmp
           _tmp = apply(:_Sp)
-          unless _tmp
-            self.pos = _save2
-            break
-          end
+          break unless _tmp
           _tmp = match_string("*")
-          unless _tmp
-            self.pos = _save2
-            break
-          end
+          break unless _tmp
           _tmp = apply(:_Sp)
-          unless _tmp
-            self.pos = _save2
-            break
-          end
+          break unless _tmp
           _tmp = match_string("*")
-          unless _tmp
-            self.pos = _save2
-            break
+          break unless _tmp
+          while true # kleene
+
+            _save2 = self.pos
+            begin # sequence
+              _tmp = apply(:_Sp)
+              break unless _tmp
+              _tmp = match_string("*")
+            end while false
+            unless _tmp
+              self.pos = _save2
+            end # end sequence
+
+            break unless _tmp
           end
-          while true
+          _tmp = true # end kleene
+        end while false
+        unless _tmp
+          self.pos = _save1
+        end # end sequence
+
+        break if _tmp
+
+        _save3 = self.pos
+        begin # sequence
+          _tmp = match_string("-")
+          break unless _tmp
+          _tmp = apply(:_Sp)
+          break unless _tmp
+          _tmp = match_string("-")
+          break unless _tmp
+          _tmp = apply(:_Sp)
+          break unless _tmp
+          _tmp = match_string("-")
+          break unless _tmp
+          while true # kleene
 
             _save4 = self.pos
-            while true # sequence
+            begin # sequence
               _tmp = apply(:_Sp)
-              unless _tmp
-                self.pos = _save4
-                break
-              end
-              _tmp = match_string("*")
-              unless _tmp
-                self.pos = _save4
-              end
-              break
+              break unless _tmp
+              _tmp = match_string("-")
+            end while false
+            unless _tmp
+              self.pos = _save4
             end # end sequence
 
             break unless _tmp
           end
-          _tmp = true
-          unless _tmp
-            self.pos = _save2
-          end
-          break
+          _tmp = true # end kleene
+        end while false
+        unless _tmp
+          self.pos = _save3
         end # end sequence
 
         break if _tmp
-        self.pos = _save1
 
         _save5 = self.pos
-        while true # sequence
-          _tmp = match_string("-")
-          unless _tmp
-            self.pos = _save5
-            break
-          end
-          _tmp = apply(:_Sp)
-          unless _tmp
-            self.pos = _save5
-            break
-          end
-          _tmp = match_string("-")
-          unless _tmp
-            self.pos = _save5
-            break
-          end
-          _tmp = apply(:_Sp)
-          unless _tmp
-            self.pos = _save5
-            break
-          end
-          _tmp = match_string("-")
-          unless _tmp
-            self.pos = _save5
-            break
-          end
-          while true
-
-            _save7 = self.pos
-            while true # sequence
-              _tmp = apply(:_Sp)
-              unless _tmp
-                self.pos = _save7
-                break
-              end
-              _tmp = match_string("-")
-              unless _tmp
-                self.pos = _save7
-              end
-              break
-            end # end sequence
-
-            break unless _tmp
-          end
-          _tmp = true
-          unless _tmp
-            self.pos = _save5
-          end
-          break
-        end # end sequence
-
-        break if _tmp
-        self.pos = _save1
-
-        _save8 = self.pos
-        while true # sequence
+        begin # sequence
           _tmp = match_string("_")
-          unless _tmp
-            self.pos = _save8
-            break
-          end
-          _tmp = apply(:_Sp)
-          unless _tmp
-            self.pos = _save8
-            break
-          end
-          _tmp = match_string("_")
-          unless _tmp
-            self.pos = _save8
-            break
-          end
-          _tmp = apply(:_Sp)
-          unless _tmp
-            self.pos = _save8
-            break
-          end
-          _tmp = match_string("_")
-          unless _tmp
-            self.pos = _save8
-            break
-          end
-          while true
-
-            _save10 = self.pos
-            while true # sequence
-              _tmp = apply(:_Sp)
-              unless _tmp
-                self.pos = _save10
-                break
-              end
-              _tmp = match_string("_")
-              unless _tmp
-                self.pos = _save10
-              end
-              break
-            end # end sequence
-
-            break unless _tmp
-          end
-          _tmp = true
-          unless _tmp
-            self.pos = _save8
-          end
-          break
-        end # end sequence
-
-        break if _tmp
-        self.pos = _save1
-        break
-      end # end choice
-
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = apply(:_Sp)
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = apply(:_Newline)
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save11 = self.pos
-      _tmp = apply(:_BlankLine)
-      if _tmp
-        while true
-          _tmp = apply(:_BlankLine)
           break unless _tmp
-        end
-        _tmp = true
-      else
-        self.pos = _save11
+          _tmp = apply(:_Sp)
+          break unless _tmp
+          _tmp = match_string("_")
+          break unless _tmp
+          _tmp = apply(:_Sp)
+          break unless _tmp
+          _tmp = match_string("_")
+          break unless _tmp
+          while true # kleene
+
+            _save6 = self.pos
+            begin # sequence
+              _tmp = apply(:_Sp)
+              break unless _tmp
+              _tmp = match_string("_")
+            end while false
+            unless _tmp
+              self.pos = _save6
+            end # end sequence
+
+            break unless _tmp
+          end
+          _tmp = true # end kleene
+        end while false
+        unless _tmp
+          self.pos = _save5
+        end # end sequence
+
+      end while false # end choice
+
+      break unless _tmp
+      _tmp = apply(:_Sp)
+      break unless _tmp
+      _tmp = apply(:_Newline)
+      break unless _tmp
+      _save7 = self.pos # repetition
+      _count = 0
+      while true
+        _tmp = apply(:_BlankLine)
+        break unless _tmp
+        _count += 1
       end
+      _tmp = _count >= 1
       unless _tmp
-        self.pos = _save
-        break
-      end
+        self.pos = _save7
+      end # end repetition
+      break unless _tmp
       @result = begin; horizontal_rule(self, position); end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_HorizontalRule unless _tmp
@@ -1476,54 +1214,38 @@ class TinyMarkdown::Parser
   def _Bullet
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _save1 = self.pos
       _tmp = apply(:_HorizontalRule)
-      _tmp = _tmp ? nil : true
+      _tmp = !_tmp
       self.pos = _save1
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       _tmp = apply(:_NonindentSpace)
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
 
-      _save2 = self.pos
-      while true # choice
+      begin # choice
         _tmp = match_string("+")
         break if _tmp
-        self.pos = _save2
         _tmp = match_string("*")
         break if _tmp
-        self.pos = _save2
         _tmp = match_string("-")
-        break if _tmp
-        self.pos = _save2
-        break
-      end # end choice
+      end while false # end choice
 
+      break unless _tmp
+      _save2 = self.pos # repetition
+      _count = 0
+      while true
+        _tmp = apply(:_Spacechar)
+        break unless _tmp
+        _count += 1
+      end
+      _tmp = _count >= 1
       unless _tmp
-        self.pos = _save
-        break
-      end
-      _save3 = self.pos
-      _tmp = apply(:_Spacechar)
-      if _tmp
-        while true
-          _tmp = apply(:_Spacechar)
-          break unless _tmp
-        end
-        _tmp = true
-      else
-        self.pos = _save3
-      end
-      unless _tmp
-        self.pos = _save
-      end
-      break
+        self.pos = _save2
+      end # end repetition
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_Bullet unless _tmp
@@ -1534,26 +1256,19 @@ class TinyMarkdown::Parser
   def _BulletList
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _save1 = self.pos
       _tmp = apply(:_Bullet)
       self.pos = _save1
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       _tmp = apply(:_ListTight)
       c = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       @result = begin; bullet_list(self, position, c); end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_BulletList unless _tmp
@@ -1564,50 +1279,38 @@ class TinyMarkdown::Parser
   def _ListTight
 
     _save = self.pos
-    while true # sequence
-      _save1 = self.pos
+    begin # sequence
+      _save1 = self.pos # repetition
       _ary = []
-      _tmp = apply(:_ListItemTight)
-      if _tmp
-        _ary << @result
-        while true
-          _tmp = apply(:_ListItemTight)
-          _ary << @result if _tmp
-          break unless _tmp
-        end
-        _tmp = true
-        @result = _ary
-      else
-        self.pos = _save1
-      end
-      cc = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
       while true
+        _tmp = apply(:_ListItemTight)
+        break unless _tmp
+        _ary << @result
+      end
+      @result = _ary
+      _tmp = _ary.size >= 1
+      unless _tmp
+        self.pos = _save1
+        @result = nil
+      end # end repetition
+      cc = @result
+      break unless _tmp
+      while true # kleene
         _tmp = apply(:_BlankLine)
         break unless _tmp
       end
-      _tmp = true
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save3 = self.pos
+      _tmp = true # end kleene
+      break unless _tmp
+      _save2 = self.pos
       _tmp = apply(:_Bullet)
-      _tmp = _tmp ? nil : true
-      self.pos = _save3
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  cc ; end
+      _tmp = !_tmp
+      self.pos = _save2
+      break unless _tmp
+      @result = begin; cc; end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_ListTight unless _tmp
@@ -1618,24 +1321,17 @@ class TinyMarkdown::Parser
   def _ListItemTight
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _tmp = apply(:_Bullet)
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       _tmp = apply(:_ListBlock)
       c = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       @result = begin; bullet_list_item(self, position, c); end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_ListItemTight unless _tmp
@@ -1646,40 +1342,30 @@ class TinyMarkdown::Parser
   def _ListBlock
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _save1 = self.pos
       _tmp = apply(:_BlankLine)
-      _tmp = _tmp ? nil : true
+      _tmp = !_tmp
       self.pos = _save1
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       _tmp = apply(:_Line)
       c = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _ary = []
+      break unless _tmp
+      _ary = [] # kleene
       while true
         _tmp = apply(:_ListBlockLine)
-        _ary << @result if _tmp
         break unless _tmp
+        _ary << @result
       end
-      _tmp = true
       @result = _ary
+      _tmp = true # end kleene
       cc = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  cc.unshift(c) ; end
+      break unless _tmp
+      @result = begin; cc.unshift(c); end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_ListBlock unless _tmp
@@ -1690,55 +1376,38 @@ class TinyMarkdown::Parser
   def _ListBlockLine
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _save1 = self.pos
       _tmp = apply(:_BlankLine)
-      _tmp = _tmp ? nil : true
+      _tmp = !_tmp
       self.pos = _save1
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       _save2 = self.pos
 
       _save3 = self.pos
-      while true # sequence
-        _save4 = self.pos
+      begin # sequence
+        # optional
         _tmp = apply(:_Indent)
-        unless _tmp
-          _tmp = true
-          self.pos = _save4
-        end
-        unless _tmp
-          self.pos = _save3
-          break
-        end
+        _tmp = true # end optional
+        break unless _tmp
         _tmp = apply(:_Bullet)
-        unless _tmp
-          self.pos = _save3
-        end
-        break
+      end while false
+      unless _tmp
+        self.pos = _save3
       end # end sequence
 
-      _tmp = _tmp ? nil : true
+      _tmp = !_tmp
       self.pos = _save2
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save5 = self.pos
+      break unless _tmp
+      _save4 = self.pos
       _tmp = apply(:_HorizontalRule)
-      _tmp = _tmp ? nil : true
-      self.pos = _save5
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      _tmp = !_tmp
+      self.pos = _save4
+      break unless _tmp
       _tmp = apply(:_OptionallyIndentedLine)
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_ListBlockLine unless _tmp
@@ -1749,159 +1418,70 @@ class TinyMarkdown::Parser
   def _Inlines
 
     _save = self.pos
-    while true # sequence
-      _save1 = self.pos
+    begin # sequence
+      _save1 = self.pos # repetition
       _ary = []
+      while true
 
-      _save2 = self.pos
-      while true # choice
+        begin # choice
 
-        _save3 = self.pos
-        while true # sequence
+          _save2 = self.pos
+          begin # sequence
+            _save3 = self.pos
+            _tmp = apply(:_Endline)
+            _tmp = !_tmp
+            self.pos = _save3
+            break unless _tmp
+            _tmp = apply(:_Inline)
+            c = @result
+            break unless _tmp
+            @result = begin; c; end
+            _tmp = true
+          end while false
+          unless _tmp
+            self.pos = _save2
+          end # end sequence
+
+          break if _tmp
+
           _save4 = self.pos
-          _tmp = apply(:_Endline)
-          _tmp = _tmp ? nil : true
-          self.pos = _save4
-          unless _tmp
-            self.pos = _save3
-            break
-          end
-          _tmp = apply(:_Inline)
-          c = @result
-          unless _tmp
-            self.pos = _save3
-            break
-          end
-          @result = begin;  c ; end
-          _tmp = true
-          unless _tmp
-            self.pos = _save3
-          end
-          break
-        end # end sequence
-
-        break if _tmp
-        self.pos = _save2
-
-        _save5 = self.pos
-        while true # sequence
-          _tmp = apply(:_Endline)
-          c = @result
-          unless _tmp
+          begin # sequence
+            _tmp = apply(:_Endline)
+            c = @result
+            break unless _tmp
+            _save5 = self.pos
+            _tmp = apply(:_Inline)
             self.pos = _save5
-            break
-          end
-          _save6 = self.pos
-          _tmp = apply(:_Inline)
-          self.pos = _save6
+            break unless _tmp
+            @result = begin; c; end
+            _tmp = true
+          end while false
           unless _tmp
-            self.pos = _save5
-            break
-          end
-          @result = begin;  c ; end
-          _tmp = true
-          unless _tmp
-            self.pos = _save5
-          end
-          break
-        end # end sequence
+            self.pos = _save4
+          end # end sequence
 
-        break if _tmp
-        self.pos = _save2
-        break
-      end # end choice
+        end while false # end choice
 
-      if _tmp
+        break unless _tmp
         _ary << @result
-        while true
-
-          _save7 = self.pos
-          while true # choice
-
-            _save8 = self.pos
-            while true # sequence
-              _save9 = self.pos
-              _tmp = apply(:_Endline)
-              _tmp = _tmp ? nil : true
-              self.pos = _save9
-              unless _tmp
-                self.pos = _save8
-                break
-              end
-              _tmp = apply(:_Inline)
-              c = @result
-              unless _tmp
-                self.pos = _save8
-                break
-              end
-              @result = begin;  c ; end
-              _tmp = true
-              unless _tmp
-                self.pos = _save8
-              end
-              break
-            end # end sequence
-
-            break if _tmp
-            self.pos = _save7
-
-            _save10 = self.pos
-            while true # sequence
-              _tmp = apply(:_Endline)
-              c = @result
-              unless _tmp
-                self.pos = _save10
-                break
-              end
-              _save11 = self.pos
-              _tmp = apply(:_Inline)
-              self.pos = _save11
-              unless _tmp
-                self.pos = _save10
-                break
-              end
-              @result = begin;  c ; end
-              _tmp = true
-              unless _tmp
-                self.pos = _save10
-              end
-              break
-            end # end sequence
-
-            break if _tmp
-            self.pos = _save7
-            break
-          end # end choice
-
-          _ary << @result if _tmp
-          break unless _tmp
-        end
-        _tmp = true
-        @result = _ary
-      else
+      end
+      @result = _ary
+      _tmp = _ary.size >= 1
+      unless _tmp
         self.pos = _save1
-      end
+        @result = nil
+      end # end repetition
       cc = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save12 = self.pos
+      break unless _tmp
+      # optional
       _tmp = apply(:_Endline)
-      unless _tmp
-        _tmp = true
-        self.pos = _save12
-      end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  cc ; end
+      _tmp = true # end optional
+      break unless _tmp
+      @result = begin; cc; end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_Inlines unless _tmp
@@ -1911,31 +1491,21 @@ class TinyMarkdown::Parser
   # Inline = (Str | Endline | Space | Strong | Emph | Code | Symbol)
   def _Inline
 
-    _save = self.pos
-    while true # choice
+    begin # choice
       _tmp = apply(:_Str)
       break if _tmp
-      self.pos = _save
       _tmp = apply(:_Endline)
       break if _tmp
-      self.pos = _save
       _tmp = apply(:_Space)
       break if _tmp
-      self.pos = _save
       _tmp = apply(:_Strong)
       break if _tmp
-      self.pos = _save
       _tmp = apply(:_Emph)
       break if _tmp
-      self.pos = _save
       _tmp = apply(:_Code)
       break if _tmp
-      self.pos = _save
       _tmp = apply(:_Symbol)
-      break if _tmp
-      self.pos = _save
-      break
-    end # end choice
+    end while false # end choice
 
     set_failed_rule :_Inline unless _tmp
     return _tmp
@@ -1945,33 +1515,27 @@ class TinyMarkdown::Parser
   def _Space
 
     _save = self.pos
-    while true # sequence
-      _save1 = self.pos
+    begin # sequence
+      _save1 = self.pos # repetition
       _ary = []
-      _tmp = apply(:_Spacechar)
-      if _tmp
+      while true
+        _tmp = apply(:_Spacechar)
+        break unless _tmp
         _ary << @result
-        while true
-          _tmp = apply(:_Spacechar)
-          _ary << @result if _tmp
-          break unless _tmp
-        end
-        _tmp = true
-        @result = _ary
-      else
-        self.pos = _save1
       end
-      c = @result
+      @result = _ary
+      _tmp = _ary.size >= 1
       unless _tmp
-        self.pos = _save
-        break
-      end
+        self.pos = _save1
+        @result = nil
+      end # end repetition
+      c = @result
+      break unless _tmp
       @result = begin; text(self, position, c.join("")); end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_Space unless _tmp
@@ -1982,46 +1546,37 @@ class TinyMarkdown::Parser
   def _Str
 
     _save = self.pos
-    while true # sequence
-      _save1 = self.pos
-      _ary = []
-      _tmp = apply(:_NormalChar)
-      if _tmp
-        _ary << @result
-        while true
-          _tmp = apply(:_NormalChar)
-          _ary << @result if _tmp
-          break unless _tmp
-        end
-        _tmp = true
-        @result = _ary
-      else
-        self.pos = _save1
-      end
-      c1 = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
+    begin # sequence
+      _save1 = self.pos # repetition
       _ary = []
       while true
-        _tmp = apply(:_StrChunk)
-        _ary << @result if _tmp
+        _tmp = apply(:_NormalChar)
         break unless _tmp
+        _ary << @result
       end
-      _tmp = true
       @result = _ary
-      c2 = @result
+      _tmp = _ary.size >= 1
       unless _tmp
-        self.pos = _save
-        break
+        self.pos = _save1
+        @result = nil
+      end # end repetition
+      c1 = @result
+      break unless _tmp
+      _ary1 = [] # kleene
+      while true
+        _tmp = apply(:_StrChunk)
+        break unless _tmp
+        _ary1 << @result
       end
+      @result = _ary1
+      _tmp = true # end kleene
+      c2 = @result
+      break unless _tmp
       @result = begin; text(self, position, (c1+c2).join("")); end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_Str unless _tmp
@@ -2032,159 +1587,72 @@ class TinyMarkdown::Parser
   def _StrChunk
 
     _save = self.pos
-    while true # sequence
-      _save1 = self.pos
+    begin # sequence
+      _save1 = self.pos # repetition
       _ary = []
+      while true
 
-      _save2 = self.pos
-      while true # choice
+        begin # choice
 
-        _save3 = self.pos
-        while true # sequence
-          _tmp = apply(:_NormalChar)
-          c = @result
+          _save2 = self.pos
+          begin # sequence
+            _tmp = apply(:_NormalChar)
+            c = @result
+            break unless _tmp
+            @result = begin; [c]; end
+            _tmp = true
+          end while false
           unless _tmp
-            self.pos = _save3
-            break
-          end
-          @result = begin;  [c] ; end
-          _tmp = true
-          unless _tmp
-            self.pos = _save3
-          end
-          break
-        end # end sequence
+            self.pos = _save2
+          end # end sequence
 
-        break if _tmp
-        self.pos = _save2
+          break if _tmp
 
-        _save4 = self.pos
-        while true # sequence
-          _save5 = self.pos
-          _ary = []
-          _tmp = match_string("_")
-          if _tmp
-            _ary << @result
+          _save3 = self.pos
+          begin # sequence
+            _save4 = self.pos # repetition
+            _ary1 = []
             while true
               _tmp = match_string("_")
-              _ary << @result if _tmp
               break unless _tmp
+              _ary1 << @result
             end
+            @result = _ary1
+            _tmp = _ary1.size >= 1
+            unless _tmp
+              self.pos = _save4
+              @result = nil
+            end # end repetition
+            c1 = @result
+            break unless _tmp
+            _tmp = apply(:_NormalChar)
+            c2 = @result
+            break unless _tmp
+            @result = begin; c1.push(c2); end
             _tmp = true
-            @result = _ary
-          else
-            self.pos = _save5
-          end
-          c1 = @result
+          end while false
           unless _tmp
-            self.pos = _save4
-            break
-          end
-          _tmp = apply(:_NormalChar)
-          c2 = @result
-          unless _tmp
-            self.pos = _save4
-            break
-          end
-          @result = begin;  c1.push(c2) ; end
-          _tmp = true
-          unless _tmp
-            self.pos = _save4
-          end
-          break
-        end # end sequence
+            self.pos = _save3
+          end # end sequence
 
-        break if _tmp
-        self.pos = _save2
-        break
-      end # end choice
+        end while false # end choice
 
-      if _tmp
+        break unless _tmp
         _ary << @result
-        while true
-
-          _save6 = self.pos
-          while true # choice
-
-            _save7 = self.pos
-            while true # sequence
-              _tmp = apply(:_NormalChar)
-              c = @result
-              unless _tmp
-                self.pos = _save7
-                break
-              end
-              @result = begin;  [c] ; end
-              _tmp = true
-              unless _tmp
-                self.pos = _save7
-              end
-              break
-            end # end sequence
-
-            break if _tmp
-            self.pos = _save6
-
-            _save8 = self.pos
-            while true # sequence
-              _save9 = self.pos
-              _ary = []
-              _tmp = match_string("_")
-              if _tmp
-                _ary << @result
-                while true
-                  _tmp = match_string("_")
-                  _ary << @result if _tmp
-                  break unless _tmp
-                end
-                _tmp = true
-                @result = _ary
-              else
-                self.pos = _save9
-              end
-              c1 = @result
-              unless _tmp
-                self.pos = _save8
-                break
-              end
-              _tmp = apply(:_NormalChar)
-              c2 = @result
-              unless _tmp
-                self.pos = _save8
-                break
-              end
-              @result = begin;  c1.push(c2) ; end
-              _tmp = true
-              unless _tmp
-                self.pos = _save8
-              end
-              break
-            end # end sequence
-
-            break if _tmp
-            self.pos = _save6
-            break
-          end # end choice
-
-          _ary << @result if _tmp
-          break unless _tmp
-        end
-        _tmp = true
-        @result = _ary
-      else
+      end
+      @result = _ary
+      _tmp = _ary.size >= 1
+      unless _tmp
         self.pos = _save1
-      end
+        @result = nil
+      end # end repetition
       cc = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  cc.flatten ; end
+      break unless _tmp
+      @result = begin; cc.flatten; end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_StrChunk unless _tmp
@@ -2194,19 +1662,13 @@ class TinyMarkdown::Parser
   # Endline = (LineBreak | TerminalEndline | NormalEndline)
   def _Endline
 
-    _save = self.pos
-    while true # choice
+    begin # choice
       _tmp = apply(:_LineBreak)
       break if _tmp
-      self.pos = _save
       _tmp = apply(:_TerminalEndline)
       break if _tmp
-      self.pos = _save
       _tmp = apply(:_NormalEndline)
-      break if _tmp
-      self.pos = _save
-      break
-    end # end choice
+    end while false # end choice
 
     set_failed_rule :_Endline unless _tmp
     return _tmp
@@ -2216,105 +1678,74 @@ class TinyMarkdown::Parser
   def _NormalEndline
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _tmp = apply(:_Sp)
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       _tmp = apply(:_Newline)
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       _save1 = self.pos
       _tmp = apply(:_BlankLine)
-      _tmp = _tmp ? nil : true
+      _tmp = !_tmp
       self.pos = _save1
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       _save2 = self.pos
       _tmp = match_string(">")
-      _tmp = _tmp ? nil : true
+      _tmp = !_tmp
       self.pos = _save2
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       _save3 = self.pos
       _tmp = apply(:_AtxStart)
-      _tmp = _tmp ? nil : true
+      _tmp = !_tmp
       self.pos = _save3
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       _save4 = self.pos
 
       _save5 = self.pos
-      while true # sequence
+      begin # sequence
         _tmp = apply(:_Line)
-        unless _tmp
-          self.pos = _save5
-          break
-        end
+        break unless _tmp
 
-        _save6 = self.pos
-        while true # choice
-          _save7 = self.pos
-          _tmp = match_string("=")
-          if _tmp
-            while true
-              _tmp = match_string("=")
-              break unless _tmp
-            end
-            _tmp = true
-          else
+        begin # choice
+          _save6 = self.pos # repetition
+          _count = 0
+          while true
+            _tmp = match_string("=")
+            break unless _tmp
+            _count += 1
+          end
+          _tmp = _count >= 1
+          unless _tmp
+            self.pos = _save6
+          end # end repetition
+          break if _tmp
+          _save7 = self.pos # repetition
+          _count1 = 0
+          while true
+            _tmp = match_string("-")
+            break unless _tmp
+            _count1 += 1
+          end
+          _tmp = _count1 >= 1
+          unless _tmp
             self.pos = _save7
-          end
-          break if _tmp
-          self.pos = _save6
-          _save8 = self.pos
-          _tmp = match_string("-")
-          if _tmp
-            while true
-              _tmp = match_string("-")
-              break unless _tmp
-            end
-            _tmp = true
-          else
-            self.pos = _save8
-          end
-          break if _tmp
-          self.pos = _save6
-          break
-        end # end choice
+          end # end repetition
+        end while false # end choice
 
-        unless _tmp
-          self.pos = _save5
-          break
-        end
+        break unless _tmp
         _tmp = apply(:_Newline)
-        unless _tmp
-          self.pos = _save5
-        end
-        break
+      end while false
+      unless _tmp
+        self.pos = _save5
       end # end sequence
 
-      _tmp = _tmp ? nil : true
+      _tmp = !_tmp
       self.pos = _save4
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       @result = begin; text(self, position, "\n"); end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_NormalEndline unless _tmp
@@ -2325,28 +1756,18 @@ class TinyMarkdown::Parser
   def _TerminalEndline
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _tmp = apply(:_Sp)
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       _tmp = apply(:_Newline)
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       _tmp = apply(:_Eof)
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       @result = begin; text(self, position, "\n"); end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_TerminalEndline unless _tmp
@@ -2357,23 +1778,16 @@ class TinyMarkdown::Parser
   def _LineBreak
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _tmp = match_string("  ")
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       _tmp = apply(:_NormalEndline)
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       @result = begin; linebreak(self, position); end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_LineBreak unless _tmp
@@ -2384,19 +1798,15 @@ class TinyMarkdown::Parser
   def _Symbol
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _tmp = apply(:_SpecialChar)
       c = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       @result = begin; text(self, position, c); end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_Symbol unless _tmp
@@ -2406,16 +1816,11 @@ class TinyMarkdown::Parser
   # Emph = (EmphStar | EmphUl)
   def _Emph
 
-    _save = self.pos
-    while true # choice
+    begin # choice
       _tmp = apply(:_EmphStar)
       break if _tmp
-      self.pos = _save
       _tmp = apply(:_EmphUl)
-      break if _tmp
-      self.pos = _save
-      break
-    end # end choice
+    end while false # end choice
 
     set_failed_rule :_Emph unless _tmp
     return _tmp
@@ -2424,16 +1829,11 @@ class TinyMarkdown::Parser
   # Whitespace = (Spacechar | Newline)
   def _Whitespace
 
-    _save = self.pos
-    while true # choice
+    begin # choice
       _tmp = apply(:_Spacechar)
       break if _tmp
-      self.pos = _save
       _tmp = apply(:_Newline)
-      break if _tmp
-      self.pos = _save
-      break
-    end # end choice
+    end while false # end choice
 
     set_failed_rule :_Whitespace unless _tmp
     return _tmp
@@ -2443,153 +1843,71 @@ class TinyMarkdown::Parser
   def _EmphStar
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _tmp = match_string("*")
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       _save1 = self.pos
       _tmp = apply(:_Whitespace)
-      _tmp = _tmp ? nil : true
+      _tmp = !_tmp
       self.pos = _save1
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save2 = self.pos
+      break unless _tmp
+      _save2 = self.pos # repetition
       _ary = []
+      while true
 
-      _save3 = self.pos
-      while true # choice
+        begin # choice
 
-        _save4 = self.pos
-        while true # sequence
+          _save3 = self.pos
+          begin # sequence
+            _save4 = self.pos
+            _tmp = match_string("*")
+            _tmp = !_tmp
+            self.pos = _save4
+            break unless _tmp
+            _tmp = apply(:_Inline)
+            b = @result
+            break unless _tmp
+            @result = begin; b; end
+            _tmp = true
+          end while false
+          unless _tmp
+            self.pos = _save3
+          end # end sequence
+
+          break if _tmp
+
           _save5 = self.pos
-          _tmp = match_string("*")
-          _tmp = _tmp ? nil : true
-          self.pos = _save5
+          begin # sequence
+            _tmp = apply(:_StrongStar)
+            b = @result
+            break unless _tmp
+            @result = begin; b; end
+            _tmp = true
+          end while false
           unless _tmp
-            self.pos = _save4
-            break
-          end
-          _tmp = apply(:_Inline)
-          b = @result
-          unless _tmp
-            self.pos = _save4
-            break
-          end
-          @result = begin;  b ; end
-          _tmp = true
-          unless _tmp
-            self.pos = _save4
-          end
-          break
-        end # end sequence
+            self.pos = _save5
+          end # end sequence
 
-        break if _tmp
-        self.pos = _save3
+        end while false # end choice
 
-        _save6 = self.pos
-        while true # sequence
-          _tmp = apply(:_StrongStar)
-          b = @result
-          unless _tmp
-            self.pos = _save6
-            break
-          end
-          @result = begin;  b ; end
-          _tmp = true
-          unless _tmp
-            self.pos = _save6
-          end
-          break
-        end # end sequence
-
-        break if _tmp
-        self.pos = _save3
-        break
-      end # end choice
-
-      if _tmp
+        break unless _tmp
         _ary << @result
-        while true
-
-          _save7 = self.pos
-          while true # choice
-
-            _save8 = self.pos
-            while true # sequence
-              _save9 = self.pos
-              _tmp = match_string("*")
-              _tmp = _tmp ? nil : true
-              self.pos = _save9
-              unless _tmp
-                self.pos = _save8
-                break
-              end
-              _tmp = apply(:_Inline)
-              b = @result
-              unless _tmp
-                self.pos = _save8
-                break
-              end
-              @result = begin;  b ; end
-              _tmp = true
-              unless _tmp
-                self.pos = _save8
-              end
-              break
-            end # end sequence
-
-            break if _tmp
-            self.pos = _save7
-
-            _save10 = self.pos
-            while true # sequence
-              _tmp = apply(:_StrongStar)
-              b = @result
-              unless _tmp
-                self.pos = _save10
-                break
-              end
-              @result = begin;  b ; end
-              _tmp = true
-              unless _tmp
-                self.pos = _save10
-              end
-              break
-            end # end sequence
-
-            break if _tmp
-            self.pos = _save7
-            break
-          end # end choice
-
-          _ary << @result if _tmp
-          break unless _tmp
-        end
-        _tmp = true
-        @result = _ary
-      else
+      end
+      @result = _ary
+      _tmp = _ary.size >= 1
+      unless _tmp
         self.pos = _save2
-      end
+        @result = nil
+      end # end repetition
       c = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       _tmp = match_string("*")
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       @result = begin; inline_element(self, position, :em, c); end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_EmphStar unless _tmp
@@ -2600,153 +1918,71 @@ class TinyMarkdown::Parser
   def _EmphUl
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _tmp = match_string("_")
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       _save1 = self.pos
       _tmp = apply(:_Whitespace)
-      _tmp = _tmp ? nil : true
+      _tmp = !_tmp
       self.pos = _save1
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save2 = self.pos
+      break unless _tmp
+      _save2 = self.pos # repetition
       _ary = []
+      while true
 
-      _save3 = self.pos
-      while true # choice
+        begin # choice
 
-        _save4 = self.pos
-        while true # sequence
+          _save3 = self.pos
+          begin # sequence
+            _save4 = self.pos
+            _tmp = match_string("_")
+            _tmp = !_tmp
+            self.pos = _save4
+            break unless _tmp
+            _tmp = apply(:_Inline)
+            b = @result
+            break unless _tmp
+            @result = begin; b; end
+            _tmp = true
+          end while false
+          unless _tmp
+            self.pos = _save3
+          end # end sequence
+
+          break if _tmp
+
           _save5 = self.pos
-          _tmp = match_string("_")
-          _tmp = _tmp ? nil : true
-          self.pos = _save5
+          begin # sequence
+            _tmp = apply(:_StrongUl)
+            b = @result
+            break unless _tmp
+            @result = begin; b; end
+            _tmp = true
+          end while false
           unless _tmp
-            self.pos = _save4
-            break
-          end
-          _tmp = apply(:_Inline)
-          b = @result
-          unless _tmp
-            self.pos = _save4
-            break
-          end
-          @result = begin;  b ; end
-          _tmp = true
-          unless _tmp
-            self.pos = _save4
-          end
-          break
-        end # end sequence
+            self.pos = _save5
+          end # end sequence
 
-        break if _tmp
-        self.pos = _save3
+        end while false # end choice
 
-        _save6 = self.pos
-        while true # sequence
-          _tmp = apply(:_StrongUl)
-          b = @result
-          unless _tmp
-            self.pos = _save6
-            break
-          end
-          @result = begin;  b ; end
-          _tmp = true
-          unless _tmp
-            self.pos = _save6
-          end
-          break
-        end # end sequence
-
-        break if _tmp
-        self.pos = _save3
-        break
-      end # end choice
-
-      if _tmp
+        break unless _tmp
         _ary << @result
-        while true
-
-          _save7 = self.pos
-          while true # choice
-
-            _save8 = self.pos
-            while true # sequence
-              _save9 = self.pos
-              _tmp = match_string("_")
-              _tmp = _tmp ? nil : true
-              self.pos = _save9
-              unless _tmp
-                self.pos = _save8
-                break
-              end
-              _tmp = apply(:_Inline)
-              b = @result
-              unless _tmp
-                self.pos = _save8
-                break
-              end
-              @result = begin;  b ; end
-              _tmp = true
-              unless _tmp
-                self.pos = _save8
-              end
-              break
-            end # end sequence
-
-            break if _tmp
-            self.pos = _save7
-
-            _save10 = self.pos
-            while true # sequence
-              _tmp = apply(:_StrongUl)
-              b = @result
-              unless _tmp
-                self.pos = _save10
-                break
-              end
-              @result = begin;  b ; end
-              _tmp = true
-              unless _tmp
-                self.pos = _save10
-              end
-              break
-            end # end sequence
-
-            break if _tmp
-            self.pos = _save7
-            break
-          end # end choice
-
-          _ary << @result if _tmp
-          break unless _tmp
-        end
-        _tmp = true
-        @result = _ary
-      else
+      end
+      @result = _ary
+      _tmp = _ary.size >= 1
+      unless _tmp
         self.pos = _save2
-      end
+        @result = nil
+      end # end repetition
       c = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       _tmp = match_string("_")
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       @result = begin; inline_element(self, position, :em, c); end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_EmphUl unless _tmp
@@ -2756,16 +1992,11 @@ class TinyMarkdown::Parser
   # Strong = (StrongStar | StrongUl)
   def _Strong
 
-    _save = self.pos
-    while true # choice
+    begin # choice
       _tmp = apply(:_StrongStar)
       break if _tmp
-      self.pos = _save
       _tmp = apply(:_StrongUl)
-      break if _tmp
-      self.pos = _save
-      break
-    end # end choice
+    end while false # end choice
 
     set_failed_rule :_Strong unless _tmp
     return _tmp
@@ -2775,99 +2006,53 @@ class TinyMarkdown::Parser
   def _StrongStar
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _tmp = match_string("**")
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       _save1 = self.pos
       _tmp = apply(:_Whitespace)
-      _tmp = _tmp ? nil : true
+      _tmp = !_tmp
       self.pos = _save1
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save2 = self.pos
+      break unless _tmp
+      _save2 = self.pos # repetition
       _ary = []
+      while true
 
-      _save3 = self.pos
-      while true # sequence
-        _save4 = self.pos
-        _tmp = match_string("**")
-        _tmp = _tmp ? nil : true
-        self.pos = _save4
-        unless _tmp
-          self.pos = _save3
-          break
-        end
-        _tmp = apply(:_Inline)
-        b = @result
-        unless _tmp
-          self.pos = _save3
-          break
-        end
-        @result = begin;  b ; end
-        _tmp = true
-        unless _tmp
-          self.pos = _save3
-        end
-        break
-      end # end sequence
-
-      if _tmp
-        _ary << @result
-        while true
-
-          _save5 = self.pos
-          while true # sequence
-            _save6 = self.pos
-            _tmp = match_string("**")
-            _tmp = _tmp ? nil : true
-            self.pos = _save6
-            unless _tmp
-              self.pos = _save5
-              break
-            end
-            _tmp = apply(:_Inline)
-            b = @result
-            unless _tmp
-              self.pos = _save5
-              break
-            end
-            @result = begin;  b ; end
-            _tmp = true
-            unless _tmp
-              self.pos = _save5
-            end
-            break
-          end # end sequence
-
-          _ary << @result if _tmp
+        _save3 = self.pos
+        begin # sequence
+          _save4 = self.pos
+          _tmp = match_string("**")
+          _tmp = !_tmp
+          self.pos = _save4
           break unless _tmp
-        end
-        _tmp = true
-        @result = _ary
-      else
+          _tmp = apply(:_Inline)
+          b = @result
+          break unless _tmp
+          @result = begin; b; end
+          _tmp = true
+        end while false
+        unless _tmp
+          self.pos = _save3
+        end # end sequence
+
+        break unless _tmp
+        _ary << @result
+      end
+      @result = _ary
+      _tmp = _ary.size >= 1
+      unless _tmp
         self.pos = _save2
-      end
+        @result = nil
+      end # end repetition
       c = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       _tmp = match_string("**")
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       @result = begin; inline_element(self, position, :strong, c); end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_StrongStar unless _tmp
@@ -2878,99 +2063,53 @@ class TinyMarkdown::Parser
   def _StrongUl
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _tmp = match_string("__")
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       _save1 = self.pos
       _tmp = apply(:_Whitespace)
-      _tmp = _tmp ? nil : true
+      _tmp = !_tmp
       self.pos = _save1
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save2 = self.pos
+      break unless _tmp
+      _save2 = self.pos # repetition
       _ary = []
+      while true
 
-      _save3 = self.pos
-      while true # sequence
-        _save4 = self.pos
-        _tmp = match_string("__")
-        _tmp = _tmp ? nil : true
-        self.pos = _save4
-        unless _tmp
-          self.pos = _save3
-          break
-        end
-        _tmp = apply(:_Inline)
-        b = @result
-        unless _tmp
-          self.pos = _save3
-          break
-        end
-        @result = begin;  b ; end
-        _tmp = true
-        unless _tmp
-          self.pos = _save3
-        end
-        break
-      end # end sequence
-
-      if _tmp
-        _ary << @result
-        while true
-
-          _save5 = self.pos
-          while true # sequence
-            _save6 = self.pos
-            _tmp = match_string("__")
-            _tmp = _tmp ? nil : true
-            self.pos = _save6
-            unless _tmp
-              self.pos = _save5
-              break
-            end
-            _tmp = apply(:_Inline)
-            b = @result
-            unless _tmp
-              self.pos = _save5
-              break
-            end
-            @result = begin;  b ; end
-            _tmp = true
-            unless _tmp
-              self.pos = _save5
-            end
-            break
-          end # end sequence
-
-          _ary << @result if _tmp
+        _save3 = self.pos
+        begin # sequence
+          _save4 = self.pos
+          _tmp = match_string("__")
+          _tmp = !_tmp
+          self.pos = _save4
           break unless _tmp
-        end
-        _tmp = true
-        @result = _ary
-      else
+          _tmp = apply(:_Inline)
+          b = @result
+          break unless _tmp
+          @result = begin; b; end
+          _tmp = true
+        end while false
+        unless _tmp
+          self.pos = _save3
+        end # end sequence
+
+        break unless _tmp
+        _ary << @result
+      end
+      @result = _ary
+      _tmp = _ary.size >= 1
+      unless _tmp
         self.pos = _save2
-      end
+        @result = nil
+      end # end repetition
       c = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       _tmp = match_string("__")
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       @result = begin; inline_element(self, position, :strong, c); end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_StrongUl unless _tmp
@@ -2981,30 +2120,23 @@ class TinyMarkdown::Parser
   def _Ticks1
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _text_start = self.pos
       _tmp = scan(/\G(?-mix:`)/)
       if _tmp
         text = get_text(_text_start)
       end
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       _save1 = self.pos
       _tmp = match_string("`")
-      _tmp = _tmp ? nil : true
+      _tmp = !_tmp
       self.pos = _save1
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  text ; end
+      break unless _tmp
+      @result = begin; text; end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_Ticks1 unless _tmp
@@ -3015,30 +2147,23 @@ class TinyMarkdown::Parser
   def _Ticks2
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _text_start = self.pos
       _tmp = scan(/\G(?-mix:``)/)
       if _tmp
         text = get_text(_text_start)
       end
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       _save1 = self.pos
       _tmp = match_string("`")
-      _tmp = _tmp ? nil : true
+      _tmp = !_tmp
       self.pos = _save1
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  text ; end
+      break unless _tmp
+      @result = begin; text; end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_Ticks2 unless _tmp
@@ -3049,198 +2174,111 @@ class TinyMarkdown::Parser
   def _Code
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
 
-      _save1 = self.pos
-      while true # choice
+      begin # choice
 
-        _save2 = self.pos
-        while true # sequence
+        _save1 = self.pos
+        begin # sequence
           _tmp = apply(:_Ticks1)
-          unless _tmp
-            self.pos = _save2
-            break
-          end
+          break unless _tmp
           _tmp = apply(:_Sp)
-          unless _tmp
-            self.pos = _save2
-            break
-          end
-          _save3 = self.pos
+          break unless _tmp
+          _save2 = self.pos # repetition
           _ary = []
+          while true
 
-          _save4 = self.pos
-          while true # sequence
-            _save5 = self.pos
-            _tmp = match_string("`")
-            _tmp = _tmp ? nil : true
-            self.pos = _save5
-            unless _tmp
+            _save3 = self.pos
+            begin # sequence
+              _save4 = self.pos
+              _tmp = match_string("`")
+              _tmp = !_tmp
               self.pos = _save4
-              break
-            end
-            _tmp = apply(:_Nonspacechar)
-            unless _tmp
-              self.pos = _save4
-            end
-            break
-          end # end sequence
-
-          if _tmp
-            _ary << @result
-            while true
-
-              _save6 = self.pos
-              while true # sequence
-                _save7 = self.pos
-                _tmp = match_string("`")
-                _tmp = _tmp ? nil : true
-                self.pos = _save7
-                unless _tmp
-                  self.pos = _save6
-                  break
-                end
-                _tmp = apply(:_Nonspacechar)
-                unless _tmp
-                  self.pos = _save6
-                end
-                break
-              end # end sequence
-
-              _ary << @result if _tmp
               break unless _tmp
-            end
-            _tmp = true
-            @result = _ary
-          else
-            self.pos = _save3
+              _tmp = apply(:_Nonspacechar)
+            end while false
+            unless _tmp
+              self.pos = _save3
+            end # end sequence
+
+            break unless _tmp
+            _ary << @result
           end
+          @result = _ary
+          _tmp = _ary.size >= 1
+          unless _tmp
+            self.pos = _save2
+            @result = nil
+          end # end repetition
           c = @result
-          unless _tmp
-            self.pos = _save2
-            break
-          end
+          break unless _tmp
           _tmp = apply(:_Sp)
-          unless _tmp
-            self.pos = _save2
-            break
-          end
+          break unless _tmp
           _tmp = apply(:_Ticks1)
-          unless _tmp
-            self.pos = _save2
-            break
-          end
+          break unless _tmp
           @result = begin; text(self, position, c.join("")); end
           _tmp = true
-          unless _tmp
-            self.pos = _save2
-          end
-          break
+        end while false
+        unless _tmp
+          self.pos = _save1
         end # end sequence
 
         break if _tmp
-        self.pos = _save1
 
-        _save8 = self.pos
-        while true # sequence
+        _save5 = self.pos
+        begin # sequence
           _tmp = apply(:_Ticks2)
-          unless _tmp
-            self.pos = _save8
-            break
-          end
+          break unless _tmp
           _tmp = apply(:_Sp)
-          unless _tmp
-            self.pos = _save8
-            break
-          end
-          _save9 = self.pos
-          _ary = []
+          break unless _tmp
+          _save6 = self.pos # repetition
+          _ary1 = []
+          while true
 
-          _save10 = self.pos
-          while true # sequence
-            _save11 = self.pos
-            _tmp = match_string("``")
-            _tmp = _tmp ? nil : true
-            self.pos = _save11
-            unless _tmp
-              self.pos = _save10
-              break
-            end
-            _tmp = apply(:_Nonspacechar)
-            unless _tmp
-              self.pos = _save10
-            end
-            break
-          end # end sequence
-
-          if _tmp
-            _ary << @result
-            while true
-
-              _save12 = self.pos
-              while true # sequence
-                _save13 = self.pos
-                _tmp = match_string("``")
-                _tmp = _tmp ? nil : true
-                self.pos = _save13
-                unless _tmp
-                  self.pos = _save12
-                  break
-                end
-                _tmp = apply(:_Nonspacechar)
-                unless _tmp
-                  self.pos = _save12
-                end
-                break
-              end # end sequence
-
-              _ary << @result if _tmp
+            _save7 = self.pos
+            begin # sequence
+              _save8 = self.pos
+              _tmp = match_string("``")
+              _tmp = !_tmp
+              self.pos = _save8
               break unless _tmp
-            end
-            _tmp = true
-            @result = _ary
-          else
-            self.pos = _save9
+              _tmp = apply(:_Nonspacechar)
+            end while false
+            unless _tmp
+              self.pos = _save7
+            end # end sequence
+
+            break unless _tmp
+            _ary1 << @result
           end
+          @result = _ary1
+          _tmp = _ary1.size >= 1
+          unless _tmp
+            self.pos = _save6
+            @result = nil
+          end # end repetition
           c = @result
-          unless _tmp
-            self.pos = _save8
-            break
-          end
+          break unless _tmp
           _tmp = apply(:_Sp)
-          unless _tmp
-            self.pos = _save8
-            break
-          end
+          break unless _tmp
           _tmp = apply(:_Ticks2)
-          unless _tmp
-            self.pos = _save8
-            break
-          end
+          break unless _tmp
           @result = begin; text(self, position, c.join("")); end
           _tmp = true
-          unless _tmp
-            self.pos = _save8
-          end
-          break
+        end while false
+        unless _tmp
+          self.pos = _save5
         end # end sequence
 
-        break if _tmp
-        self.pos = _save1
-        break
-      end # end choice
+      end while false # end choice
 
       cc = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       @result = begin; inline_element(self, position, :code, [cc]); end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_Code unless _tmp
@@ -3251,17 +2289,13 @@ class TinyMarkdown::Parser
   def _BlankLine
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _tmp = apply(:_Sp)
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       _tmp = apply(:_Newline)
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_BlankLine unless _tmp
@@ -3271,96 +2305,69 @@ class TinyMarkdown::Parser
   # Quoted = ("\"" (!"\"" .)* "\"" | "'" (!"'" .)* "'")
   def _Quoted
 
-    _save = self.pos
-    while true # choice
+    begin # choice
 
-      _save1 = self.pos
-      while true # sequence
+      _save = self.pos
+      begin # sequence
         _tmp = match_string("\"")
-        unless _tmp
-          self.pos = _save1
-          break
-        end
-        while true
+        break unless _tmp
+        while true # kleene
 
-          _save3 = self.pos
-          while true # sequence
-            _save4 = self.pos
+          _save1 = self.pos
+          begin # sequence
+            _save2 = self.pos
             _tmp = match_string("\"")
-            _tmp = _tmp ? nil : true
-            self.pos = _save4
-            unless _tmp
-              self.pos = _save3
-              break
-            end
-            _tmp = get_byte
-            unless _tmp
-              self.pos = _save3
-            end
-            break
+            _tmp = !_tmp
+            self.pos = _save2
+            break unless _tmp
+            _tmp = match_dot
+          end while false
+          unless _tmp
+            self.pos = _save1
           end # end sequence
 
           break unless _tmp
         end
-        _tmp = true
-        unless _tmp
-          self.pos = _save1
-          break
-        end
+        _tmp = true # end kleene
+        break unless _tmp
         _tmp = match_string("\"")
-        unless _tmp
-          self.pos = _save1
-        end
-        break
+      end while false
+      unless _tmp
+        self.pos = _save
       end # end sequence
 
       break if _tmp
-      self.pos = _save
 
-      _save5 = self.pos
-      while true # sequence
+      _save3 = self.pos
+      begin # sequence
         _tmp = match_string("'")
-        unless _tmp
-          self.pos = _save5
-          break
-        end
-        while true
+        break unless _tmp
+        while true # kleene
 
-          _save7 = self.pos
-          while true # sequence
-            _save8 = self.pos
+          _save4 = self.pos
+          begin # sequence
+            _save5 = self.pos
             _tmp = match_string("'")
-            _tmp = _tmp ? nil : true
-            self.pos = _save8
-            unless _tmp
-              self.pos = _save7
-              break
-            end
-            _tmp = get_byte
-            unless _tmp
-              self.pos = _save7
-            end
-            break
+            _tmp = !_tmp
+            self.pos = _save5
+            break unless _tmp
+            _tmp = match_dot
+          end while false
+          unless _tmp
+            self.pos = _save4
           end # end sequence
 
           break unless _tmp
         end
-        _tmp = true
-        unless _tmp
-          self.pos = _save5
-          break
-        end
+        _tmp = true # end kleene
+        break unless _tmp
         _tmp = match_string("'")
-        unless _tmp
-          self.pos = _save5
-        end
-        break
+      end while false
+      unless _tmp
+        self.pos = _save3
       end # end sequence
 
-      break if _tmp
-      self.pos = _save
-      break
-    end # end choice
+    end while false # end choice
 
     set_failed_rule :_Quoted unless _tmp
     return _tmp
@@ -3369,8 +2376,8 @@ class TinyMarkdown::Parser
   # Eof = !.
   def _Eof
     _save = self.pos
-    _tmp = get_byte
-    _tmp = _tmp ? nil : true
+    _tmp = match_dot
+    _tmp = !_tmp
     self.pos = _save
     set_failed_rule :_Eof unless _tmp
     return _tmp
@@ -3380,22 +2387,18 @@ class TinyMarkdown::Parser
   def _Spacechar
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _text_start = self.pos
       _tmp = scan(/\G(?-mix: |\t)/)
       if _tmp
         text = get_text(_text_start)
       end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  text ; end
+      break unless _tmp
+      @result = begin; text; end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_Spacechar unless _tmp
@@ -3406,38 +2409,28 @@ class TinyMarkdown::Parser
   def _Nonspacechar
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _save1 = self.pos
       _tmp = apply(:_Spacechar)
-      _tmp = _tmp ? nil : true
+      _tmp = !_tmp
       self.pos = _save1
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       _save2 = self.pos
       _tmp = apply(:_Newline)
-      _tmp = _tmp ? nil : true
+      _tmp = !_tmp
       self.pos = _save2
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       _text_start = self.pos
-      _tmp = get_byte
+      _tmp = match_dot
       if _tmp
         text = get_text(_text_start)
       end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  text ; end
+      break unless _tmp
+      @result = begin; text; end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_Nonspacechar unless _tmp
@@ -3447,35 +2440,23 @@ class TinyMarkdown::Parser
   # Newline = ("\n" | "\r" "\n"?)
   def _Newline
 
-    _save = self.pos
-    while true # choice
+    begin # choice
       _tmp = match_string("\n")
       break if _tmp
-      self.pos = _save
 
-      _save1 = self.pos
-      while true # sequence
+      _save = self.pos
+      begin # sequence
         _tmp = match_string("\r")
-        unless _tmp
-          self.pos = _save1
-          break
-        end
-        _save2 = self.pos
+        break unless _tmp
+        # optional
         _tmp = match_string("\n")
-        unless _tmp
-          _tmp = true
-          self.pos = _save2
-        end
-        unless _tmp
-          self.pos = _save1
-        end
-        break
+        _tmp = true # end optional
+      end while false
+      unless _tmp
+        self.pos = _save
       end # end sequence
 
-      break if _tmp
-      self.pos = _save
-      break
-    end # end choice
+    end while false # end choice
 
     set_failed_rule :_Newline unless _tmp
     return _tmp
@@ -3483,11 +2464,11 @@ class TinyMarkdown::Parser
 
   # Sp = Spacechar*
   def _Sp
-    while true
+    while true # kleene
       _tmp = apply(:_Spacechar)
       break unless _tmp
     end
-    _tmp = true
+    _tmp = true # end kleene
     set_failed_rule :_Sp unless _tmp
     return _tmp
   end
@@ -3496,36 +2477,25 @@ class TinyMarkdown::Parser
   def _Spnl
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _tmp = apply(:_Sp)
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save1 = self.pos
+      break unless _tmp
+      # optional
 
-      _save2 = self.pos
-      while true # sequence
+      _save1 = self.pos
+      begin # sequence
         _tmp = apply(:_Newline)
-        unless _tmp
-          self.pos = _save2
-          break
-        end
+        break unless _tmp
         _tmp = apply(:_Sp)
-        unless _tmp
-          self.pos = _save2
-        end
-        break
+      end while false
+      unless _tmp
+        self.pos = _save1
       end # end sequence
 
-      unless _tmp
-        _tmp = true
-        self.pos = _save1
-      end
-      unless _tmp
-        self.pos = _save
-      end
-      break
+      _tmp = true # end optional
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_Spnl unless _tmp
@@ -3536,22 +2506,18 @@ class TinyMarkdown::Parser
   def _SpecialChar
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _text_start = self.pos
       _tmp = scan(/\G(?-mix:[~*_`&\[\]()<!#\\'"])/)
       if _tmp
         text = get_text(_text_start)
       end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  text ; end
+      break unless _tmp
+      @result = begin; text; end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_SpecialChar unless _tmp
@@ -3562,44 +2528,31 @@ class TinyMarkdown::Parser
   def _NormalChar
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _save1 = self.pos
 
-      _save2 = self.pos
-      while true # choice
+      begin # choice
         _tmp = apply(:_SpecialChar)
         break if _tmp
-        self.pos = _save2
         _tmp = apply(:_Spacechar)
         break if _tmp
-        self.pos = _save2
         _tmp = apply(:_Newline)
-        break if _tmp
-        self.pos = _save2
-        break
-      end # end choice
+      end while false # end choice
 
-      _tmp = _tmp ? nil : true
+      _tmp = !_tmp
       self.pos = _save1
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       _text_start = self.pos
-      _tmp = get_byte
+      _tmp = match_dot
       if _tmp
         text = get_text(_text_start)
       end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  text ; end
+      break unless _tmp
+      @result = begin; text; end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_NormalChar unless _tmp
@@ -3610,22 +2563,18 @@ class TinyMarkdown::Parser
   def _AlphanumericAscii
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _text_start = self.pos
       _tmp = scan(/\G(?-mix:[A-Za-z0-9])/)
       if _tmp
         text = get_text(_text_start)
       end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  text ; end
+      break unless _tmp
+      @result = begin; text; end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_AlphanumericAscii unless _tmp
@@ -3636,22 +2585,18 @@ class TinyMarkdown::Parser
   def _Digit
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _text_start = self.pos
       _tmp = scan(/\G(?-mix:[0-9])/)
       if _tmp
         text = get_text(_text_start)
       end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  text ; end
+      break unless _tmp
+      @result = begin; text; end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_Digit unless _tmp
@@ -3662,22 +2607,18 @@ class TinyMarkdown::Parser
   def _NonindentSpace
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _text_start = self.pos
       _tmp = scan(/\G(?-mix:   |  | |)/)
       if _tmp
         text = get_text(_text_start)
       end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  text ; end
+      break unless _tmp
+      @result = begin; text; end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_NonindentSpace unless _tmp
@@ -3688,22 +2629,18 @@ class TinyMarkdown::Parser
   def _Indent
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _text_start = self.pos
       _tmp = scan(/\G(?-mix:\t|    )/)
       if _tmp
         text = get_text(_text_start)
       end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  text ; end
+      break unless _tmp
+      @result = begin; text; end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_Indent unless _tmp
@@ -3714,24 +2651,17 @@ class TinyMarkdown::Parser
   def _IndentedLine
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _tmp = apply(:_Indent)
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       _tmp = apply(:_Line)
       c = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  c ; end
+      break unless _tmp
+      @result = begin; c; end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_IndentedLine unless _tmp
@@ -3742,22 +2672,15 @@ class TinyMarkdown::Parser
   def _OptionallyIndentedLine
 
     _save = self.pos
-    while true # sequence
-      _save1 = self.pos
+    begin # sequence
+      # optional
       _tmp = apply(:_Indent)
-      unless _tmp
-        _tmp = true
-        self.pos = _save1
-      end
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      _tmp = true # end optional
+      break unless _tmp
       _tmp = apply(:_Line)
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_OptionallyIndentedLine unless _tmp
@@ -3768,19 +2691,15 @@ class TinyMarkdown::Parser
   def _Line
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _tmp = apply(:_RawLine)
       c = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  c ; end
+      break unless _tmp
+      @result = begin; c; end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_Line unless _tmp
@@ -3791,78 +2710,55 @@ class TinyMarkdown::Parser
   def _RawLine
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
 
-      _save1 = self.pos
-      while true # choice
+      begin # choice
 
-        _save2 = self.pos
-        while true # sequence
+        _save1 = self.pos
+        begin # sequence
           _text_start = self.pos
           _tmp = scan(/\G(?-mix:[^\r\n]*)/)
           if _tmp
             text = get_text(_text_start)
           end
-          unless _tmp
-            self.pos = _save2
-            break
-          end
+          break unless _tmp
           _tmp = apply(:_Newline)
-          unless _tmp
-            self.pos = _save2
-            break
-          end
-          @result = begin;  text ; end
+          break unless _tmp
+          @result = begin; text; end
           _tmp = true
-          unless _tmp
-            self.pos = _save2
-          end
-          break
+        end while false
+        unless _tmp
+          self.pos = _save1
         end # end sequence
 
         break if _tmp
-        self.pos = _save1
 
-        _save3 = self.pos
-        while true # sequence
+        _save2 = self.pos
+        begin # sequence
           _text_start = self.pos
           _tmp = scan(/\G(?-mix:.+)/)
           if _tmp
             text = get_text(_text_start)
           end
-          unless _tmp
-            self.pos = _save3
-            break
-          end
+          break unless _tmp
           _tmp = apply(:_Eof)
-          unless _tmp
-            self.pos = _save3
-            break
-          end
-          @result = begin;  text ; end
+          break unless _tmp
+          @result = begin; text; end
           _tmp = true
-          unless _tmp
-            self.pos = _save3
-          end
-          break
+        end while false
+        unless _tmp
+          self.pos = _save2
         end # end sequence
 
-        break if _tmp
-        self.pos = _save1
-        break
-      end # end choice
+      end while false # end choice
 
       c = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
+      break unless _tmp
       @result = begin; text(self, position, c); end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_RawLine unless _tmp

--- a/examples/upper/upper.kpeg.rb
+++ b/examples/upper/upper.kpeg.rb
@@ -53,6 +53,9 @@ class Upper
       def current_line(target=pos)
         if line = position_line_offsets.bsearch_index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
         raise "Target position #{target} is outside of string"
       end
@@ -60,17 +63,22 @@ class Upper
       def current_line(target=pos)
         if line = position_line_offsets.index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
-
         raise "Target position #{target} is outside of string"
       end
     end
 
     def current_character(target=pos)
-      if target < 0 || target >= string.size
+      if target < 0 || target > string.size
         raise "Target position #{target} is outside of string"
+      elsif target == string.size
+        ""
+      else
+        string[target, 1]
       end
-      string[target, 1]
     end
 
     KpegPosInfo = Struct.new(:pos, :lno, :col, :line, :char)

--- a/examples/upper/upper.kpeg.rb
+++ b/examples/upper/upper.kpeg.rb
@@ -197,6 +197,15 @@ class Upper
 
     attr_reader :failed_rule
 
+    def match_dot()
+      if @pos >= @string_size
+        return nil
+      end
+
+      @pos += 1
+      true
+    end
+
     def match_string(str)
       len = str.size
       if @string[pos,len] == str
@@ -217,24 +226,26 @@ class Upper
     end
 
     if "".respond_to? :ord
-      def get_byte
+      def match_char_range(char_range)
         if @pos >= @string_size
+          return nil
+        elsif !char_range.include?(@string[@pos].ord)
           return nil
         end
 
-        s = @string[@pos].ord
         @pos += 1
-        s
+        true
       end
     else
-      def get_byte
+      def match_char_range(char_range)
         if @pos >= @string_size
+          return nil
+        elsif !char_range.include?(@string[@pos])
           return nil
         end
 
-        s = @string[@pos]
         @pos += 1
-        s
+        true
       end
     end
 
@@ -422,22 +433,18 @@ class Upper
   def _alpha
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _text_start = self.pos
       _tmp = scan(/\G(?-mix:[A-Za-z])/)
       if _tmp
         text = get_text(_text_start)
       end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  text.upcase ; end
+      break unless _tmp
+      @result = begin; text.upcase; end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_alpha unless _tmp
@@ -447,78 +454,54 @@ class Upper
   # word = (alpha:a word:w { "#{a}#{w}" } | alpha:a space { "#{a} "} | alpha:a { a })
   def _word
 
-    _save = self.pos
-    while true # choice
+    begin # choice
 
-      _save1 = self.pos
-      while true # sequence
+      _save = self.pos
+      begin # sequence
         _tmp = apply(:_alpha)
         a = @result
-        unless _tmp
-          self.pos = _save1
-          break
-        end
+        break unless _tmp
         _tmp = apply(:_word)
         w = @result
-        unless _tmp
-          self.pos = _save1
-          break
-        end
-        @result = begin;  "#{a}#{w}" ; end
+        break unless _tmp
+        @result = begin; "#{a}#{w}"; end
         _tmp = true
-        unless _tmp
-          self.pos = _save1
-        end
-        break
+      end while false
+      unless _tmp
+        self.pos = _save
       end # end sequence
 
       break if _tmp
-      self.pos = _save
+
+      _save1 = self.pos
+      begin # sequence
+        _tmp = apply(:_alpha)
+        a = @result
+        break unless _tmp
+        _tmp = apply(:_space)
+        break unless _tmp
+        @result = begin; "#{a} "; end
+        _tmp = true
+      end while false
+      unless _tmp
+        self.pos = _save1
+      end # end sequence
+
+      break if _tmp
 
       _save2 = self.pos
-      while true # sequence
+      begin # sequence
         _tmp = apply(:_alpha)
         a = @result
-        unless _tmp
-          self.pos = _save2
-          break
-        end
-        _tmp = apply(:_space)
-        unless _tmp
-          self.pos = _save2
-          break
-        end
-        @result = begin;  "#{a} "; end
+        break unless _tmp
+        @result = begin; a; end
         _tmp = true
-        unless _tmp
-          self.pos = _save2
-        end
-        break
+      end while false
+      unless _tmp
+        self.pos = _save2
       end # end sequence
 
-      break if _tmp
-      self.pos = _save
-
-      _save3 = self.pos
-      while true # sequence
-        _tmp = apply(:_alpha)
-        a = @result
-        unless _tmp
-          self.pos = _save3
-          break
-        end
-        @result = begin;  a ; end
-        _tmp = true
-        unless _tmp
-          self.pos = _save3
-        end
-        break
-      end # end sequence
-
-      break if _tmp
-      self.pos = _save
-      break
-    end # end choice
+    end while false # end choice
 
     set_failed_rule :_word unless _tmp
     return _tmp
@@ -527,54 +510,38 @@ class Upper
   # sentence = (word:w sentence:s { "#{w}#{s}" } | word:w { w })
   def _sentence
 
-    _save = self.pos
-    while true # choice
+    begin # choice
 
-      _save1 = self.pos
-      while true # sequence
+      _save = self.pos
+      begin # sequence
         _tmp = apply(:_word)
         w = @result
-        unless _tmp
-          self.pos = _save1
-          break
-        end
+        break unless _tmp
         _tmp = apply(:_sentence)
         s = @result
-        unless _tmp
-          self.pos = _save1
-          break
-        end
-        @result = begin;  "#{w}#{s}" ; end
+        break unless _tmp
+        @result = begin; "#{w}#{s}"; end
         _tmp = true
-        unless _tmp
-          self.pos = _save1
-        end
-        break
+      end while false
+      unless _tmp
+        self.pos = _save
       end # end sequence
 
       break if _tmp
-      self.pos = _save
 
-      _save2 = self.pos
-      while true # sequence
+      _save1 = self.pos
+      begin # sequence
         _tmp = apply(:_word)
         w = @result
-        unless _tmp
-          self.pos = _save2
-          break
-        end
-        @result = begin;  w ; end
+        break unless _tmp
+        @result = begin; w; end
         _tmp = true
-        unless _tmp
-          self.pos = _save2
-        end
-        break
+      end while false
+      unless _tmp
+        self.pos = _save1
       end # end sequence
 
-      break if _tmp
-      self.pos = _save
-      break
-    end # end choice
+    end while false # end choice
 
     set_failed_rule :_sentence unless _tmp
     return _tmp
@@ -583,92 +550,62 @@ class Upper
   # document = (sentence:s period space* document:d { "#{s}. #{d}" } | sentence:s period { "#{s}." } | sentence:s { "#{s}" })
   def _document
 
-    _save = self.pos
-    while true # choice
+    begin # choice
 
-      _save1 = self.pos
-      while true # sequence
+      _save = self.pos
+      begin # sequence
         _tmp = apply(:_sentence)
         s = @result
-        unless _tmp
-          self.pos = _save1
-          break
-        end
+        break unless _tmp
         _tmp = apply(:_period)
-        unless _tmp
-          self.pos = _save1
-          break
-        end
-        while true
+        break unless _tmp
+        while true # kleene
           _tmp = apply(:_space)
           break unless _tmp
         end
-        _tmp = true
-        unless _tmp
-          self.pos = _save1
-          break
-        end
+        _tmp = true # end kleene
+        break unless _tmp
         _tmp = apply(:_document)
         d = @result
-        unless _tmp
-          self.pos = _save1
-          break
-        end
-        @result = begin;  "#{s}. #{d}" ; end
+        break unless _tmp
+        @result = begin; "#{s}. #{d}"; end
         _tmp = true
-        unless _tmp
-          self.pos = _save1
-        end
-        break
+      end while false
+      unless _tmp
+        self.pos = _save
       end # end sequence
 
       break if _tmp
-      self.pos = _save
 
-      _save3 = self.pos
-      while true # sequence
+      _save1 = self.pos
+      begin # sequence
         _tmp = apply(:_sentence)
         s = @result
-        unless _tmp
-          self.pos = _save3
-          break
-        end
+        break unless _tmp
         _tmp = apply(:_period)
-        unless _tmp
-          self.pos = _save3
-          break
-        end
-        @result = begin;  "#{s}." ; end
+        break unless _tmp
+        @result = begin; "#{s}."; end
         _tmp = true
-        unless _tmp
-          self.pos = _save3
-        end
-        break
+      end while false
+      unless _tmp
+        self.pos = _save1
       end # end sequence
 
       break if _tmp
-      self.pos = _save
 
-      _save4 = self.pos
-      while true # sequence
+      _save2 = self.pos
+      begin # sequence
         _tmp = apply(:_sentence)
         s = @result
-        unless _tmp
-          self.pos = _save4
-          break
-        end
-        @result = begin;  "#{s}" ; end
+        break unless _tmp
+        @result = begin; "#{s}"; end
         _tmp = true
-        unless _tmp
-          self.pos = _save4
-        end
-        break
+      end while false
+      unless _tmp
+        self.pos = _save2
       end # end sequence
 
-      break if _tmp
-      self.pos = _save
-      break
-    end # end choice
+    end while false # end choice
 
     set_failed_rule :_document unless _tmp
     return _tmp
@@ -678,19 +615,15 @@ class Upper
   def _root
 
     _save = self.pos
-    while true # sequence
+    begin # sequence
       _tmp = apply(:_document)
       d = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  @output = d ; end
+      break unless _tmp
+      @result = begin; @output = d; end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_root unless _tmp

--- a/examples/upper/upper.kpeg.rb
+++ b/examples/upper/upper.kpeg.rb
@@ -1,4 +1,4 @@
-class LuaString
+class Upper
   # :stopdoc:
 
     # This is distinct from setup_parser so that a standalone parser
@@ -390,23 +390,33 @@ class LuaString
   # :startdoc:
 
 
-  attr_accessor :result
+    attr_accessor :output
 
 
   # :stopdoc:
   def setup_foreign_grammar; end
 
-  # equals = < "="* > { text }
-  def _equals
+  # period = "."
+  def _period
+    _tmp = match_string(".")
+    set_failed_rule :_period unless _tmp
+    return _tmp
+  end
+
+  # space = " "
+  def _space
+    _tmp = match_string(" ")
+    set_failed_rule :_space unless _tmp
+    return _tmp
+  end
+
+  # alpha = < /[A-Za-z]/ > { text.upcase }
+  def _alpha
 
     _save = self.pos
     while true # sequence
       _text_start = self.pos
-      while true
-        _tmp = match_string("=")
-        break unless _tmp
-      end
-      _tmp = true
+      _tmp = scan(/\G(?-mix:[A-Za-z])/)
       if _tmp
         text = get_text(_text_start)
       end
@@ -414,7 +424,7 @@ class LuaString
         self.pos = _save
         break
       end
-      @result = begin;  text ; end
+      @result = begin;  text.upcase ; end
       _tmp = true
       unless _tmp
         self.pos = _save
@@ -422,103 +432,252 @@ class LuaString
       break
     end # end sequence
 
-    set_failed_rule :_equals unless _tmp
+    set_failed_rule :_alpha unless _tmp
     return _tmp
   end
 
-  # equal_ending = "]" equals:x &{ x == start } "]"
-  def _equal_ending(start)
+  # word = (alpha:a word:w { "#{a}#{w}" } | alpha:a space { "#{a} "} | alpha:a { a })
+  def _word
 
     _save = self.pos
-    while true # sequence
-      _tmp = match_string("]")
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = apply(:_equals)
-      x = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _save1 = self.pos
-      _tmp = begin;  x == start ; end
-      self.pos = _save1
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = match_string("]")
-      unless _tmp
-        self.pos = _save
-      end
-      break
-    end # end sequence
+    while true # choice
 
-    set_failed_rule :_equal_ending unless _tmp
+      _save1 = self.pos
+      while true # sequence
+        _tmp = apply(:_alpha)
+        a = @result
+        unless _tmp
+          self.pos = _save1
+          break
+        end
+        _tmp = apply(:_word)
+        w = @result
+        unless _tmp
+          self.pos = _save1
+          break
+        end
+        @result = begin;  "#{a}#{w}" ; end
+        _tmp = true
+        unless _tmp
+          self.pos = _save1
+        end
+        break
+      end # end sequence
+
+      break if _tmp
+      self.pos = _save
+
+      _save2 = self.pos
+      while true # sequence
+        _tmp = apply(:_alpha)
+        a = @result
+        unless _tmp
+          self.pos = _save2
+          break
+        end
+        _tmp = apply(:_space)
+        unless _tmp
+          self.pos = _save2
+          break
+        end
+        @result = begin;  "#{a} "; end
+        _tmp = true
+        unless _tmp
+          self.pos = _save2
+        end
+        break
+      end # end sequence
+
+      break if _tmp
+      self.pos = _save
+
+      _save3 = self.pos
+      while true # sequence
+        _tmp = apply(:_alpha)
+        a = @result
+        unless _tmp
+          self.pos = _save3
+          break
+        end
+        @result = begin;  a ; end
+        _tmp = true
+        unless _tmp
+          self.pos = _save3
+        end
+        break
+      end # end sequence
+
+      break if _tmp
+      self.pos = _save
+      break
+    end # end choice
+
+    set_failed_rule :_word unless _tmp
     return _tmp
   end
 
-  # root = "[" equals:e "[" < (!equal_ending(e) .)* > equal_ending(e) {          @result = text        }
+  # sentence = (word:w sentence:s { "#{w}#{s}" } | word:w { w })
+  def _sentence
+
+    _save = self.pos
+    while true # choice
+
+      _save1 = self.pos
+      while true # sequence
+        _tmp = apply(:_word)
+        w = @result
+        unless _tmp
+          self.pos = _save1
+          break
+        end
+        _tmp = apply(:_sentence)
+        s = @result
+        unless _tmp
+          self.pos = _save1
+          break
+        end
+        @result = begin;  "#{w}#{s}" ; end
+        _tmp = true
+        unless _tmp
+          self.pos = _save1
+        end
+        break
+      end # end sequence
+
+      break if _tmp
+      self.pos = _save
+
+      _save2 = self.pos
+      while true # sequence
+        _tmp = apply(:_word)
+        w = @result
+        unless _tmp
+          self.pos = _save2
+          break
+        end
+        @result = begin;  w ; end
+        _tmp = true
+        unless _tmp
+          self.pos = _save2
+        end
+        break
+      end # end sequence
+
+      break if _tmp
+      self.pos = _save
+      break
+    end # end choice
+
+    set_failed_rule :_sentence unless _tmp
+    return _tmp
+  end
+
+  # document = (sentence:s period space* document:d { "#{s}. #{d}" } | sentence:s period { "#{s}." } | sentence:s { "#{s}" })
+  def _document
+
+    _save = self.pos
+    while true # choice
+
+      _save1 = self.pos
+      while true # sequence
+        _tmp = apply(:_sentence)
+        s = @result
+        unless _tmp
+          self.pos = _save1
+          break
+        end
+        _tmp = apply(:_period)
+        unless _tmp
+          self.pos = _save1
+          break
+        end
+        while true
+          _tmp = apply(:_space)
+          break unless _tmp
+        end
+        _tmp = true
+        unless _tmp
+          self.pos = _save1
+          break
+        end
+        _tmp = apply(:_document)
+        d = @result
+        unless _tmp
+          self.pos = _save1
+          break
+        end
+        @result = begin;  "#{s}. #{d}" ; end
+        _tmp = true
+        unless _tmp
+          self.pos = _save1
+        end
+        break
+      end # end sequence
+
+      break if _tmp
+      self.pos = _save
+
+      _save3 = self.pos
+      while true # sequence
+        _tmp = apply(:_sentence)
+        s = @result
+        unless _tmp
+          self.pos = _save3
+          break
+        end
+        _tmp = apply(:_period)
+        unless _tmp
+          self.pos = _save3
+          break
+        end
+        @result = begin;  "#{s}." ; end
+        _tmp = true
+        unless _tmp
+          self.pos = _save3
+        end
+        break
+      end # end sequence
+
+      break if _tmp
+      self.pos = _save
+
+      _save4 = self.pos
+      while true # sequence
+        _tmp = apply(:_sentence)
+        s = @result
+        unless _tmp
+          self.pos = _save4
+          break
+        end
+        @result = begin;  "#{s}" ; end
+        _tmp = true
+        unless _tmp
+          self.pos = _save4
+        end
+        break
+      end # end sequence
+
+      break if _tmp
+      self.pos = _save
+      break
+    end # end choice
+
+    set_failed_rule :_document unless _tmp
+    return _tmp
+  end
+
+  # root = document:d { @output = d }
   def _root
 
     _save = self.pos
     while true # sequence
-      _tmp = match_string("[")
+      _tmp = apply(:_document)
+      d = @result
       unless _tmp
         self.pos = _save
         break
       end
-      _tmp = apply(:_equals)
-      e = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = match_string("[")
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _text_start = self.pos
-      while true
-
-        _save2 = self.pos
-        while true # sequence
-          _save3 = self.pos
-          _tmp = apply_with_args(:_equal_ending, e)
-          _tmp = _tmp ? nil : true
-          self.pos = _save3
-          unless _tmp
-            self.pos = _save2
-            break
-          end
-          _tmp = get_byte
-          unless _tmp
-            self.pos = _save2
-          end
-          break
-        end # end sequence
-
-        break unless _tmp
-      end
-      _tmp = true
-      if _tmp
-        text = get_text(_text_start)
-      end
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      _tmp = apply_with_args(:_equal_ending, e)
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin; 
-         @result = text
-       ; end
+      @result = begin;  @output = d ; end
       _tmp = true
       unless _tmp
         self.pos = _save
@@ -531,8 +690,12 @@ class LuaString
   end
 
   Rules = {}
-  Rules[:_equals] = rule_info("equals", "< \"=\"* > { text }")
-  Rules[:_equal_ending] = rule_info("equal_ending", "\"]\" equals:x &{ x == start } \"]\"")
-  Rules[:_root] = rule_info("root", "\"[\" equals:e \"[\" < (!equal_ending(e) .)* > equal_ending(e) {          @result = text        }")
+  Rules[:_period] = rule_info("period", "\".\"")
+  Rules[:_space] = rule_info("space", "\" \"")
+  Rules[:_alpha] = rule_info("alpha", "< /[A-Za-z]/ > { text.upcase }")
+  Rules[:_word] = rule_info("word", "(alpha:a word:w { \"\#{a}\#{w}\" } | alpha:a space { \"\#{a} \"} | alpha:a { a })")
+  Rules[:_sentence] = rule_info("sentence", "(word:w sentence:s { \"\#{w}\#{s}\" } | word:w { w })")
+  Rules[:_document] = rule_info("document", "(sentence:s period space* document:d { \"\#{s}. \#{d}\" } | sentence:s period { \"\#{s}.\" } | sentence:s { \"\#{s}\" })")
+  Rules[:_root] = rule_info("root", "document:d { @output = d }")
   # :startdoc:
 end

--- a/lib/kpeg/compiled_parser.rb
+++ b/lib/kpeg/compiled_parser.rb
@@ -131,6 +131,15 @@ module KPeg
 
     attr_reader :failed_rule
 
+    def match_dot()
+      if @pos >= @string_size
+        return nil
+      end
+
+      @pos += 1
+      true
+    end
+
     def match_string(str)
       len = str.size
       if @string[pos,len] == str
@@ -151,24 +160,26 @@ module KPeg
     end
 
     if "".respond_to? :ord
-      def get_byte
+      def match_char_range(char_range)
         if @pos >= @string_size
+          return nil
+        elsif !char_range.include?(@string[@pos].ord)
           return nil
         end
 
-        s = @string[@pos].ord
         @pos += 1
-        s
+        true
       end
     else
-      def get_byte
+      def match_char_range(char_range)
         if @pos >= @string_size
+          return nil
+        elsif !char_range.include?(@string[@pos])
           return nil
         end
 
-        s = @string[@pos]
         @pos += 1
-        s
+        true
       end
     end
 

--- a/lib/kpeg/format_parser.rb
+++ b/lib/kpeg/format_parser.rb
@@ -45,6 +45,9 @@ class KPeg::FormatParser
       def current_line(target=pos)
         if line = position_line_offsets.bsearch_index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
         raise "Target position #{target} is outside of string"
       end
@@ -52,17 +55,22 @@ class KPeg::FormatParser
       def current_line(target=pos)
         if line = position_line_offsets.index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
-
         raise "Target position #{target} is outside of string"
       end
     end
 
     def current_character(target=pos)
-      if target < 0 || target >= string.size
+      if target < 0 || target > string.size
         raise "Target position #{target} is outside of string"
+      elsif target == string.size
+        ""
+      else
+        string[target, 1]
       end
-      string[target, 1]
     end
 
     KpegPosInfo = Struct.new(:pos, :lno, :col, :line, :char)

--- a/lib/kpeg/position.rb
+++ b/lib/kpeg/position.rb
@@ -28,6 +28,9 @@ module KPeg
       def current_line(target=pos)
         if line = position_line_offsets.bsearch_index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
         raise "Target position #{target} is outside of string"
       end
@@ -35,17 +38,22 @@ module KPeg
       def current_line(target=pos)
         if line = position_line_offsets.index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
-
         raise "Target position #{target} is outside of string"
       end
     end
 
     def current_character(target=pos)
-      if target < 0 || target >= string.size
+      if target < 0 || target > string.size
         raise "Target position #{target} is outside of string"
+      elsif target == string.size
+        ""
+      else
+        string[target, 1]
       end
-      string[target, 1]
     end
 
     KpegPosInfo = Struct.new(:pos, :lno, :col, :line, :char)

--- a/lib/kpeg/string_escape.rb
+++ b/lib/kpeg/string_escape.rb
@@ -197,6 +197,15 @@ class KPeg::StringEscape
 
     attr_reader :failed_rule
 
+    def match_dot()
+      if @pos >= @string_size
+        return nil
+      end
+
+      @pos += 1
+      true
+    end
+
     def match_string(str)
       len = str.size
       if @string[pos,len] == str
@@ -217,24 +226,26 @@ class KPeg::StringEscape
     end
 
     if "".respond_to? :ord
-      def get_byte
+      def match_char_range(char_range)
         if @pos >= @string_size
+          return nil
+        elsif !char_range.include?(@string[@pos].ord)
           return nil
         end
 
-        s = @string[@pos].ord
         @pos += 1
-        s
+        true
       end
     else
-      def get_byte
+      def match_char_range(char_range)
         if @pos >= @string_size
+          return nil
+        elsif !char_range.include?(@string[@pos])
           return nil
         end
 
-        s = @string[@pos]
         @pos += 1
-        s
+        true
       end
     end
 
@@ -407,162 +418,119 @@ class KPeg::StringEscape
   # segment = (< /[\w ]+/ > { text } | "\\" { "\\\\" } | "\n" { "\\n" } | "\r" { "\\r" } | "\t" { "\\t" } | "\b" { "\\b" } | "\"" { "\\\"" } | < . > { text })
   def _segment
 
-    _save = self.pos
-    while true # choice
+    begin # choice
 
-      _save1 = self.pos
-      while true # sequence
+      _save = self.pos
+      begin # sequence
         _text_start = self.pos
         _tmp = scan(/\G(?-mix:[\w ]+)/)
         if _tmp
           text = get_text(_text_start)
         end
-        unless _tmp
-          self.pos = _save1
-          break
-        end
-        @result = begin;  text ; end
+        break unless _tmp
+        @result = begin; text; end
         _tmp = true
-        unless _tmp
-          self.pos = _save1
-        end
-        break
+      end while false
+      unless _tmp
+        self.pos = _save
       end # end sequence
 
       break if _tmp
-      self.pos = _save
+
+      _save1 = self.pos
+      begin # sequence
+        _tmp = match_string("\\")
+        break unless _tmp
+        @result = begin; "\\\\"; end
+        _tmp = true
+      end while false
+      unless _tmp
+        self.pos = _save1
+      end # end sequence
+
+      break if _tmp
 
       _save2 = self.pos
-      while true # sequence
-        _tmp = match_string("\\")
-        unless _tmp
-          self.pos = _save2
-          break
-        end
-        @result = begin;  "\\\\" ; end
+      begin # sequence
+        _tmp = match_string("\n")
+        break unless _tmp
+        @result = begin; "\\n"; end
         _tmp = true
-        unless _tmp
-          self.pos = _save2
-        end
-        break
+      end while false
+      unless _tmp
+        self.pos = _save2
       end # end sequence
 
       break if _tmp
-      self.pos = _save
 
       _save3 = self.pos
-      while true # sequence
-        _tmp = match_string("\n")
-        unless _tmp
-          self.pos = _save3
-          break
-        end
-        @result = begin;  "\\n" ; end
+      begin # sequence
+        _tmp = match_string("\r")
+        break unless _tmp
+        @result = begin; "\\r"; end
         _tmp = true
-        unless _tmp
-          self.pos = _save3
-        end
-        break
+      end while false
+      unless _tmp
+        self.pos = _save3
       end # end sequence
 
       break if _tmp
-      self.pos = _save
 
       _save4 = self.pos
-      while true # sequence
-        _tmp = match_string("\r")
-        unless _tmp
-          self.pos = _save4
-          break
-        end
-        @result = begin;  "\\r" ; end
+      begin # sequence
+        _tmp = match_string("\t")
+        break unless _tmp
+        @result = begin; "\\t"; end
         _tmp = true
-        unless _tmp
-          self.pos = _save4
-        end
-        break
+      end while false
+      unless _tmp
+        self.pos = _save4
       end # end sequence
 
       break if _tmp
-      self.pos = _save
 
       _save5 = self.pos
-      while true # sequence
-        _tmp = match_string("\t")
-        unless _tmp
-          self.pos = _save5
-          break
-        end
-        @result = begin;  "\\t" ; end
+      begin # sequence
+        _tmp = match_string("\b")
+        break unless _tmp
+        @result = begin; "\\b"; end
         _tmp = true
-        unless _tmp
-          self.pos = _save5
-        end
-        break
+      end while false
+      unless _tmp
+        self.pos = _save5
       end # end sequence
 
       break if _tmp
-      self.pos = _save
 
       _save6 = self.pos
-      while true # sequence
-        _tmp = match_string("\b")
-        unless _tmp
-          self.pos = _save6
-          break
-        end
-        @result = begin;  "\\b" ; end
+      begin # sequence
+        _tmp = match_string("\"")
+        break unless _tmp
+        @result = begin; "\\\""; end
         _tmp = true
-        unless _tmp
-          self.pos = _save6
-        end
-        break
+      end while false
+      unless _tmp
+        self.pos = _save6
       end # end sequence
 
       break if _tmp
-      self.pos = _save
 
       _save7 = self.pos
-      while true # sequence
-        _tmp = match_string("\"")
-        unless _tmp
-          self.pos = _save7
-          break
-        end
-        @result = begin;  "\\\"" ; end
-        _tmp = true
-        unless _tmp
-          self.pos = _save7
-        end
-        break
-      end # end sequence
-
-      break if _tmp
-      self.pos = _save
-
-      _save8 = self.pos
-      while true # sequence
+      begin # sequence
         _text_start = self.pos
-        _tmp = get_byte
+        _tmp = match_dot
         if _tmp
           text = get_text(_text_start)
         end
-        unless _tmp
-          self.pos = _save8
-          break
-        end
-        @result = begin;  text ; end
+        break unless _tmp
+        @result = begin; text; end
         _tmp = true
-        unless _tmp
-          self.pos = _save8
-        end
-        break
+      end while false
+      unless _tmp
+        self.pos = _save7
       end # end sequence
 
-      break if _tmp
-      self.pos = _save
-      break
-    end # end choice
+    end while false # end choice
 
     set_failed_rule :_segment unless _tmp
     return _tmp
@@ -572,26 +540,22 @@ class KPeg::StringEscape
   def _root
 
     _save = self.pos
-    while true # sequence
-      _ary = []
+    begin # sequence
+      _ary = [] # kleene
       while true
         _tmp = apply(:_segment)
-        _ary << @result if _tmp
         break unless _tmp
+        _ary << @result
       end
-      _tmp = true
       @result = _ary
+      _tmp = true # end kleene
       s = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  @text = s.join ; end
+      break unless _tmp
+      @result = begin; @text = s.join; end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_root unless _tmp
@@ -601,31 +565,22 @@ class KPeg::StringEscape
   # embed_seg = ("#" { "\\#" } | segment)
   def _embed_seg
 
-    _save = self.pos
-    while true # choice
+    begin # choice
 
-      _save1 = self.pos
-      while true # sequence
+      _save = self.pos
+      begin # sequence
         _tmp = match_string("#")
-        unless _tmp
-          self.pos = _save1
-          break
-        end
-        @result = begin;  "\\#" ; end
+        break unless _tmp
+        @result = begin; "\\#"; end
         _tmp = true
-        unless _tmp
-          self.pos = _save1
-        end
-        break
+      end while false
+      unless _tmp
+        self.pos = _save
       end # end sequence
 
       break if _tmp
-      self.pos = _save
       _tmp = apply(:_segment)
-      break if _tmp
-      self.pos = _save
-      break
-    end # end choice
+    end while false # end choice
 
     set_failed_rule :_embed_seg unless _tmp
     return _tmp
@@ -635,26 +590,22 @@ class KPeg::StringEscape
   def _embed
 
     _save = self.pos
-    while true # sequence
-      _ary = []
+    begin # sequence
+      _ary = [] # kleene
       while true
         _tmp = apply(:_embed_seg)
-        _ary << @result if _tmp
         break unless _tmp
+        _ary << @result
       end
-      _tmp = true
       @result = _ary
+      _tmp = true # end kleene
       s = @result
-      unless _tmp
-        self.pos = _save
-        break
-      end
-      @result = begin;  @text = s.join ; end
+      break unless _tmp
+      @result = begin; @text = s.join; end
       _tmp = true
-      unless _tmp
-        self.pos = _save
-      end
-      break
+    end while false
+    unless _tmp
+      self.pos = _save
     end # end sequence
 
     set_failed_rule :_embed unless _tmp

--- a/lib/kpeg/string_escape.rb
+++ b/lib/kpeg/string_escape.rb
@@ -53,6 +53,9 @@ class KPeg::StringEscape
       def current_line(target=pos)
         if line = position_line_offsets.bsearch_index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
         raise "Target position #{target} is outside of string"
       end
@@ -60,17 +63,22 @@ class KPeg::StringEscape
       def current_line(target=pos)
         if line = position_line_offsets.index {|x| x > target }
           return line + 1
+        elsif target == string.size
+          past_last = !string.empty? && string[-1]=="\n" ? 1 : 0
+          return position_line_offsets.size + past_last
         end
-
         raise "Target position #{target} is outside of string"
       end
     end
 
     def current_character(target=pos)
-      if target < 0 || target >= string.size
+      if target < 0 || target > string.size
         raise "Target position #{target} is outside of string"
+      elsif target == string.size
+        ""
+      else
+        string[target, 1]
       end
-      string[target, 1]
     end
 
     KpegPosInfo = Struct.new(:pos, :lno, :col, :line, :char)

--- a/test/test_kpeg_compiled_parser.rb
+++ b/test/test_kpeg_compiled_parser.rb
@@ -29,6 +29,12 @@ class TestKPegCompiledParser < Minitest::Test
 
   KPeg.compile gram, "ProdTestParser", self
 
+  gram = <<-GRAM
+  root = [a-z] "\n"
+  GRAM
+
+  KPeg.compile gram, "TestNLParser", self
+
   def test_current_column
     r = TestParser.new "hello\nsir\nand goodbye"
     assert_equal 1, r.current_column(0)
@@ -102,6 +108,24 @@ class TestKPegCompiledParser < Minitest::Test
 
     expected = "@1:1 failed rule 'letter', got '9'"
     assert_equal expected, r.failure_oneline
+  end
+
+  def test_position_at_the_end
+    r = TestParser.new "l"
+    assert r.parse, "should parse"
+
+    assert_equal 1, r.pos
+    assert_equal 1, r.current_line
+    assert_equal 2, r.current_column
+  end
+
+  def test_position_at_the_end_after_nl
+    r = TestNLParser.new "l\n"
+    assert r.parse, "should parse"
+
+    assert_equal 2, r.pos
+    assert_equal 2, r.current_line
+    assert_equal 1, r.current_column
   end
 
   def test_composite_grammar


### PR DESCRIPTION
- make `get_byte` accept char range
- abuse choice variants reset position by themself
- abuse optional rule reset position by itself
- simplify sequence with resetting position after block instead of after each element
- unify `+` and numbered repetition
- strip actions body

Also fix issue with nested repetition collection:
- names `_ary` and `_count` were erroneously reused

Branch is made on top of #60, so first 2 commits are the same.

Obsoletes #59 